### PR TITLE
Phase 3: peer discovery and automatic mesh formation

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,11 +104,14 @@ listen = "0.0.0.0:2222"
 
 [network]
 listen = "0.0.0.0:4000"
+advertise_addr = "203.0.113.10:4000"  # explicit public address (optional)
 bootstrap = [
     "seed1.example.com:4000",
     "seed2.example.com:4000"
 ]
 max_peers = 15
+exchange_interval = "30s"   # peer exchange period
+discovery_interval = "10s"  # discovery scan period
 ```
 
 CLI flags take precedence over config file values.
@@ -134,7 +137,7 @@ micelio/
 │   ├── partyline/         # Chat hub (channel-based, zero mutexes)
 │   ├── ssh/               # SSH server, terminal sessions
 │   ├── store/             # Store interface + bbolt implementation
-│   └── transport/         # Noise encryption, wire framing, peer management
+│   └── transport/         # Noise encryption, wire framing, peer management, discovery
 ├── pkg/proto/             # Generated protobuf Go code
 ├── proto/                 # Protobuf definitions
 ├── docs/                  # Protocol documentation (MkDocs)
@@ -146,7 +149,7 @@ micelio/
 
 - [x] **Phase 1** — Standalone node with SSH partyline
 - [x] **Phase 2** — Two nodes, direct connection ([#1](../../issues/1))
-- [ ] **Phase 3** — Peer discovery and mesh formation ([#2](../../issues/2))
+- [x] **Phase 3** — Peer discovery and mesh formation ([#2](../../issues/2))
 - [ ] **Phase 4** — Gossip protocol ([#3](../../issues/3))
 - [ ] **Phase 5** — Distributed state map with LWW + Lamport clock ([#4](../../issues/4))
 - [ ] **Phase 6** — Tagging and desired state ([#5](../../issues/5))

--- a/cmd/micelio/main.go
+++ b/cmd/micelio/main.go
@@ -74,7 +74,7 @@ func main() {
 	var mgr *transport.Manager
 	if cfg.Network.Listen != "" || len(cfg.Network.Bootstrap) > 0 {
 		var err2 error
-		mgr, err2 = transport.NewManager(cfg, id, hub)
+		mgr, err2 = transport.NewManager(cfg, id, hub, store)
 		if err2 != nil {
 			log.Fatalf("transport: %v", err2)
 		}

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,12 +26,13 @@ From bottom to top:
 
 ## Current Status
 
-The protocol is implemented through Phase 2:
+The protocol is implemented through Phase 3:
 
 - **Phase 1** — Standalone node: identity generation, SSH partyline, bbolt storage.
 - **Phase 2** — Direct connections: Noise-encrypted TCP, protobuf wire protocol, PeerHello handshake, bidirectional chat relay, message signing, deduplication.
+- **Phase 3** — Peer discovery: PeerExchange messages, automatic mesh formation, persistent peer table (bbolt), exponential backoff, MaxPeers enforcement, advertise address support.
 
-Phases 3-7 (peer discovery, gossip, distributed state, tagging, plugins) are planned but not yet implemented. Messages currently propagate only to directly connected peers — there is no multi-hop relay.
+Phases 4-7 (gossip relay, distributed state, tagging, plugins) are planned but not yet implemented. Messages currently propagate only to directly connected peers — there is no multi-hop relay.
 
 ## Quick Reference
 

--- a/internal/transport/discovery.go
+++ b/internal/transport/discovery.go
@@ -1,0 +1,514 @@
+package transport
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log"
+	"math"
+	"math/rand/v2"
+	"net"
+	"time"
+
+	"github.com/google/uuid"
+	"google.golang.org/protobuf/proto"
+
+	pb "micelio/pkg/proto"
+)
+
+var peersBucket = []byte("peers")
+
+// PeerRecord represents a known peer stored in the discovery table.
+type PeerRecord struct {
+	NodeID    string `json:"node_id"`
+	Addr      string `json:"addr"`
+	Reachable bool   `json:"reachable"`
+	PublicKey string `json:"public_key"` // hex-encoded ED25519
+	LastSeen  int64  `json:"last_seen"`  // unix seconds
+	FailCount int    `json:"fail_count"`
+	LastFail  int64  `json:"last_fail"` // unix seconds
+}
+
+// backoff returns the minimum time before this peer should be retried.
+func (r *PeerRecord) backoff() time.Duration {
+	if r.FailCount <= 0 {
+		return 0
+	}
+	secs := math.Min(math.Pow(2, float64(r.FailCount-1)), 30)
+	return time.Duration(secs) * time.Second
+}
+
+const (
+	maxDialsPerTick = 3
+	maxDialJitter   = 2 * time.Second
+)
+
+// loadKnownPeers reads all peer records from the store into knownPeers.
+// Called once at startup. If store is nil, this is a no-op.
+func (m *Manager) loadKnownPeers() {
+	if m.store == nil {
+		return
+	}
+	snap, err := m.store.Snapshot(peersBucket)
+	if err != nil {
+		log.Printf("discovery: load known peers: %v", err)
+		return
+	}
+	// Unmarshal and validate outside the lock
+	var valid []*PeerRecord
+	for _, v := range snap {
+		var rec PeerRecord
+		if err := json.Unmarshal(v, &rec); err != nil {
+			log.Printf("discovery: unmarshal peer record: %v", err)
+			continue
+		}
+		if rec.NodeID == "" {
+			log.Printf("discovery: skipping peer record with empty NodeID")
+			continue
+		}
+		if rec.Addr != "" && isInvalidPeerAddr(rec.Addr) {
+			log.Printf("discovery: skipping peer %s with invalid addr %q", formatNodeIDShort(rec.NodeID), rec.Addr)
+			continue
+		}
+		// Validate public key if present: must be valid hex, correct length, and match node_id
+		if rec.PublicKey != "" {
+			pubBytes, err := hex.DecodeString(rec.PublicKey)
+			if err != nil {
+				log.Printf("discovery: skipping peer %s with invalid public key encoding", formatNodeIDShort(rec.NodeID))
+				continue
+			}
+			if len(pubBytes) != ed25519.PublicKeySize {
+				log.Printf("discovery: skipping peer %s with invalid public key length", formatNodeIDShort(rec.NodeID))
+				continue
+			}
+			hash := sha256.Sum256(pubBytes)
+			if hex.EncodeToString(hash[:]) != rec.NodeID {
+				log.Printf("discovery: skipping peer %s with mismatched pubkey", formatNodeIDShort(rec.NodeID))
+				continue
+			}
+		}
+		valid = append(valid, &rec)
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, rec := range valid {
+		m.knownPeers[rec.NodeID] = rec
+	}
+	if len(m.knownPeers) > 0 {
+		log.Printf("discovery: loaded %d known peers from store", len(m.knownPeers))
+	}
+}
+
+// saveKnownPeer persists a single peer record to the store.
+func (m *Manager) saveKnownPeer(rec *PeerRecord) {
+	if m.store == nil {
+		return
+	}
+	data, err := json.Marshal(rec)
+	if err != nil {
+		log.Printf("discovery: marshal peer record: %v", err)
+		return
+	}
+	if err := m.store.Set(peersBucket, []byte(rec.NodeID), data); err != nil {
+		log.Printf("discovery: save peer %s: %v", rec.NodeID, err)
+	}
+}
+
+// onPeerConnected is called after a peer completes the hello exchange and is
+// added to the peers map. It updates discovery state and sends an initial
+// PeerExchange.
+func (m *Manager) onPeerConnected(p *Peer) {
+	m.mu.Lock()
+	rec, ok := m.knownPeers[p.NodeID]
+	if !ok {
+		rec = &PeerRecord{NodeID: p.NodeID}
+		m.knownPeers[p.NodeID] = rec
+	}
+	rec.Addr = p.remoteListenAddr
+	rec.Reachable = p.remoteReachable
+	rec.PublicKey = hex.EncodeToString(p.edPubKey)
+	rec.LastSeen = time.Now().Unix()
+	rec.FailCount = 0
+	rec.LastFail = 0
+	snapshot := *rec // copy before releasing lock
+	m.mu.Unlock()
+
+	go m.saveKnownPeer(&snapshot)
+	m.sendPeerExchangeTo(p)
+}
+
+// exchangeLoop periodically sends PeerExchange to all connected peers.
+func (m *Manager) exchangeLoop(ctx context.Context) {
+	interval := m.cfg.Network.ExchangeInterval.Duration
+	if interval <= 0 {
+		interval = 30 * time.Second
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			m.mu.Lock()
+			peers := make([]*Peer, 0, len(m.peers))
+			for _, p := range m.peers {
+				peers = append(peers, p)
+			}
+			m.mu.Unlock()
+			for _, p := range peers {
+				m.sendPeerExchangeTo(p)
+			}
+		case <-ctx.Done():
+			return
+		case <-m.done:
+			return
+		}
+	}
+}
+
+// discoveryLoop periodically scans knownPeers and dials candidates.
+func (m *Manager) discoveryLoop(ctx context.Context) {
+	interval := m.cfg.Network.DiscoveryInterval.Duration
+	if interval <= 0 {
+		interval = 10 * time.Second
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			m.tryDiscoveryDials(ctx)
+		case <-ctx.Done():
+			return
+		case <-m.done:
+			return
+		}
+	}
+}
+
+// sendPeerExchangeTo builds and sends a PeerExchange message to a single peer.
+func (m *Manager) sendPeerExchangeTo(p *Peer) {
+	infos := m.buildPeerInfoList(p.NodeID)
+	if len(infos) == 0 {
+		return
+	}
+
+	px := &pb.PeerExchange{Peers: infos}
+	payload, err := proto.Marshal(px)
+	if err != nil {
+		log.Printf("discovery: marshal peer_exchange: %v", err)
+		return
+	}
+
+	env := &pb.Envelope{
+		MessageId: uuid.New().String(),
+		SenderId:  m.id.NodeID,
+		MsgType:   MsgTypePeerExchange,
+		HopCount:  1,
+		Payload:   payload,
+	}
+	signEnvelope(env, m.id.PrivateKey)
+
+	envBytes, err := proto.Marshal(env)
+	if err != nil {
+		log.Printf("discovery: marshal envelope: %v", err)
+		return
+	}
+
+	select {
+	case p.sendCh <- envBytes:
+	default:
+		log.Printf("discovery: send buffer full for peer %s, dropping exchange", p.NodeID)
+	}
+}
+
+// buildPeerInfoList collects reachable peers for exchange, excluding the
+// recipient and self (self is added separately if reachable).
+func (m *Manager) buildPeerInfoList(excludeNodeID string) []*pb.PeerInfo {
+	selfAddr := m.advertiseAddr()
+
+	// Snapshot minimal fields under lock to avoid holding m.mu during hex decode
+	type peerSnapshot struct {
+		nodeID       string
+		addr         string
+		reachable    bool
+		publicKeyHex string
+		lastSeen     int64
+	}
+
+	m.mu.Lock()
+	snapshots := make([]peerSnapshot, 0, len(m.knownPeers))
+	for _, rec := range m.knownPeers {
+		if rec.NodeID == excludeNodeID || rec.NodeID == m.id.NodeID {
+			continue
+		}
+		if !rec.Reachable || rec.Addr == "" || isInvalidPeerAddr(rec.Addr) {
+			continue
+		}
+		snapshots = append(snapshots, peerSnapshot{
+			nodeID:       rec.NodeID,
+			addr:         rec.Addr,
+			reachable:    rec.Reachable,
+			publicKeyHex: rec.PublicKey,
+			lastSeen:     rec.LastSeen,
+		})
+	}
+	m.mu.Unlock()
+
+	var infos []*pb.PeerInfo
+
+	// Add self if reachable
+	if selfAddr != "" {
+		infos = append(infos, &pb.PeerInfo{
+			NodeId:        m.id.NodeID,
+			Addr:          selfAddr,
+			Reachable:     true,
+			Ed25519Pubkey: m.id.PublicKey,
+			LastSeen:      uint64(time.Now().Unix()),
+		})
+	}
+
+	// Add known reachable peers (decode hex outside lock)
+	for _, s := range snapshots {
+		if s.publicKeyHex == "" {
+			continue
+		}
+		pubKey, err := hex.DecodeString(s.publicKeyHex)
+		if err != nil || len(pubKey) != ed25519.PublicKeySize {
+			continue
+		}
+		infos = append(infos, &pb.PeerInfo{
+			NodeId:        s.nodeID,
+			Addr:          s.addr,
+			Reachable:     s.reachable,
+			Ed25519Pubkey: pubKey,
+			LastSeen:      uint64(s.lastSeen),
+		})
+	}
+
+	return infos
+}
+
+// isInvalidPeerAddr returns true if addr is not a valid dialable host:port.
+// Rejects wildcard hosts (0.0.0.0, ::, empty) and malformed addresses.
+func isInvalidPeerAddr(addr string) bool {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return true // malformed, not a valid host:port
+	}
+	if port == "" {
+		return true
+	}
+	return host == "" || host == "0.0.0.0" || host == "::"
+}
+
+// safeLastSeen converts a uint64 timestamp to int64, clamping at MaxInt64.
+func safeLastSeen(ts uint64) int64 {
+	if ts > math.MaxInt64 {
+		return math.MaxInt64
+	}
+	return int64(ts)
+}
+
+// mergeDiscoveredPeers merges received PeerInfo into knownPeers and persists.
+func (m *Manager) mergeDiscoveredPeers(infos []*pb.PeerInfo, fromNodeID string) {
+	// Pre-filter and validate outside the lock (sha256, hex encoding, addr checks)
+	type validEntry struct {
+		info      *pb.PeerInfo
+		pubKeyHex string
+		lastSeen  int64
+	}
+	var validated []validEntry
+	for _, info := range infos {
+		if info.NodeId == m.id.NodeID {
+			continue
+		}
+		if !info.Reachable || info.Addr == "" || isInvalidPeerAddr(info.Addr) {
+			continue
+		}
+		if len(info.Ed25519Pubkey) != ed25519.PublicKeySize {
+			continue
+		}
+		hash := sha256.Sum256(info.Ed25519Pubkey)
+		if info.NodeId != hex.EncodeToString(hash[:]) {
+			log.Printf("discovery: ignoring peer with mismatched node_id from %s", formatNodeIDShort(fromNodeID))
+			continue
+		}
+		validated = append(validated, validEntry{
+			info:      info,
+			pubKeyHex: hex.EncodeToString(info.Ed25519Pubkey),
+			lastSeen:  safeLastSeen(info.LastSeen),
+		})
+	}
+
+	if len(validated) == 0 {
+		return
+	}
+
+	// Lock only to apply updates to knownPeers
+	m.mu.Lock()
+	var toPersist []PeerRecord
+	for _, v := range validated {
+		existing, ok := m.knownPeers[v.info.NodeId]
+		if ok {
+			if v.lastSeen > existing.LastSeen {
+				existing.Addr = v.info.Addr
+				existing.Reachable = v.info.Reachable
+				existing.PublicKey = v.pubKeyHex
+				existing.LastSeen = v.lastSeen
+				toPersist = append(toPersist, *existing)
+			}
+		} else {
+			rec := &PeerRecord{
+				NodeID:    v.info.NodeId,
+				Addr:      v.info.Addr,
+				Reachable: v.info.Reachable,
+				PublicKey:  v.pubKeyHex,
+				LastSeen:  v.lastSeen,
+			}
+			m.knownPeers[v.info.NodeId] = rec
+			toPersist = append(toPersist, *rec)
+		}
+	}
+	m.mu.Unlock()
+
+	// Persist outside the lock and off the recv goroutine to avoid stalls
+	if len(toPersist) > 0 {
+		go func(recs []PeerRecord) {
+			for i := range recs {
+				m.saveKnownPeer(&recs[i])
+			}
+		}(toPersist)
+	}
+}
+
+// tryDiscoveryDials selects candidates from knownPeers and dials them.
+func (m *Manager) tryDiscoveryDials(ctx context.Context) {
+	m.mu.Lock()
+
+	// Don't dial if at capacity
+	if m.cfg.Network.MaxPeers > 0 && len(m.peers) >= m.cfg.Network.MaxPeers {
+		m.mu.Unlock()
+		return
+	}
+
+	now := time.Now()
+	var candidates []*PeerRecord
+
+	for _, rec := range m.knownPeers {
+		// Skip self
+		if rec.NodeID == m.id.NodeID {
+			continue
+		}
+		// Must be reachable with an address
+		if !rec.Reachable || rec.Addr == "" {
+			continue
+		}
+		// Already connected
+		if _, connected := m.peers[rec.NodeID]; connected {
+			continue
+		}
+		// Already dialing
+		if m.dialing[rec.NodeID] {
+			continue
+		}
+		// Managed by bootstrap dialWithBackoff — skip to avoid double-dial
+		if m.bootstrapAddrs[rec.Addr] {
+			continue
+		}
+		// Backoff not elapsed
+		if rec.FailCount > 0 {
+			backoffEnd := time.Unix(rec.LastFail, 0).Add(rec.backoff())
+			if now.Before(backoffEnd) {
+				continue
+			}
+		}
+		// Copy record to avoid races with concurrent writes to the pointer
+		copied := *rec
+		candidates = append(candidates, &copied)
+	}
+	m.mu.Unlock()
+
+	if len(candidates) == 0 {
+		return
+	}
+
+	// Shuffle candidates
+	rand.Shuffle(len(candidates), func(i, j int) {
+		candidates[i], candidates[j] = candidates[j], candidates[i]
+	})
+
+	// Cap at maxDialsPerTick
+	if len(candidates) > maxDialsPerTick {
+		candidates = candidates[:maxDialsPerTick]
+	}
+
+	for _, rec := range candidates {
+		m.mu.Lock()
+		m.dialing[rec.NodeID] = true
+		m.mu.Unlock()
+		go m.dialDiscovered(ctx, rec)
+	}
+}
+
+// dialDiscovered dials a discovered peer with random jitter.
+func (m *Manager) dialDiscovered(ctx context.Context, rec *PeerRecord) {
+	defer func() {
+		m.mu.Lock()
+		delete(m.dialing, rec.NodeID)
+		m.mu.Unlock()
+	}()
+
+	// Random jitter 0-2s
+	jitter := time.Duration(rand.Int64N(int64(maxDialJitter)))
+	timer := time.NewTimer(jitter)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+	case <-ctx.Done():
+		return
+	case <-m.done:
+		return
+	}
+
+	if err := m.dial(rec.Addr); err != nil {
+		var snapshot *PeerRecord
+		m.mu.Lock()
+		if r, ok := m.knownPeers[rec.NodeID]; ok {
+			r.FailCount++
+			r.LastFail = time.Now().Unix()
+			s := *r
+			snapshot = &s
+		}
+		m.mu.Unlock()
+		if snapshot != nil {
+			m.saveKnownPeer(snapshot)
+		}
+		log.Printf("discovery: dial %s (%s): %v", formatNodeIDShort(rec.NodeID), rec.Addr, err)
+	}
+}
+
+// formatNodeIDShort returns first 12 chars of a node ID for logging.
+func formatNodeIDShort(nodeID string) string {
+	if len(nodeID) > 12 {
+		return nodeID[:12]
+	}
+	return nodeID
+}
+
+// peerExchangeHandler returns the callback function that the manager sets on peers
+// to handle incoming PeerExchange messages.
+func (m *Manager) peerExchangeHandler() func(string, []*pb.PeerInfo) {
+	return func(nodeID string, infos []*pb.PeerInfo) {
+		m.mergeDiscoveredPeers(infos, nodeID)
+		if count := len(infos); count > 0 {
+			log.Printf("discovery: received %d peer(s) from %s", count, formatNodeIDShort(nodeID))
+		}
+	}
+}
+
+func (r *PeerRecord) String() string {
+	return fmt.Sprintf("PeerRecord{%s addr=%s reachable=%v fails=%d}", formatNodeIDShort(r.NodeID), r.Addr, r.Reachable, r.FailCount)
+}

--- a/internal/transport/discovery_internal_test.go
+++ b/internal/transport/discovery_internal_test.go
@@ -1,0 +1,275 @@
+package transport
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+
+	"micelio/internal/config"
+	"micelio/internal/identity"
+	"micelio/internal/partyline"
+
+	pb "micelio/pkg/proto"
+)
+
+// makeTestManager creates a minimal Manager for unit-testing discovery internals.
+func makeTestManager(t *testing.T) *Manager {
+	t.Helper()
+	id, err := identity.Load(t.TempDir())
+	if err != nil {
+		t.Fatalf("identity: %v", err)
+	}
+	hub := partyline.NewHub("test")
+	cfg := &config.Config{
+		Node:    config.NodeConfig{Name: "test"},
+		Network: config.NetworkConfig{},
+	}
+	mgr, err := NewManager(cfg, id, hub, nil)
+	if err != nil {
+		t.Fatalf("manager: %v", err)
+	}
+	return mgr
+}
+
+// validPeerInfo creates a PeerInfo with correctly derived node_id.
+func validPeerInfo(t *testing.T, addr string) *pb.PeerInfo {
+	t.Helper()
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("keygen: %v", err)
+	}
+	hash := sha256.Sum256(pub)
+	return &pb.PeerInfo{
+		NodeId:        hex.EncodeToString(hash[:]),
+		Addr:          addr,
+		Reachable:     true,
+		Ed25519Pubkey: pub,
+		LastSeen:      1000,
+	}
+}
+
+func TestMergeRejectsMismatchedNodeID(t *testing.T) {
+	mgr := makeTestManager(t)
+
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("keygen: %v", err)
+	}
+	info := &pb.PeerInfo{
+		NodeId:        "0000000000000000000000000000000000000000000000000000000000000000",
+		Addr:          "10.0.0.1:4000",
+		Reachable:     true,
+		Ed25519Pubkey: pub,
+		LastSeen:      1000,
+	}
+
+	mgr.mergeDiscoveredPeers([]*pb.PeerInfo{info}, "sender")
+
+	mgr.mu.Lock()
+	defer mgr.mu.Unlock()
+	if len(mgr.knownPeers) != 0 {
+		t.Fatalf("expected 0 known peers after mismatched node_id, got %d", len(mgr.knownPeers))
+	}
+}
+
+func TestMergeRejectsWildcardAddr(t *testing.T) {
+	mgr := makeTestManager(t)
+
+	wildcards := []string{
+		"0.0.0.0:4000",
+		"[::]:4000",
+		":4000",
+	}
+	for _, addr := range wildcards {
+		info := validPeerInfo(t, addr)
+		mgr.mergeDiscoveredPeers([]*pb.PeerInfo{info}, "sender")
+	}
+
+	mgr.mu.Lock()
+	defer mgr.mu.Unlock()
+	if len(mgr.knownPeers) != 0 {
+		t.Fatalf("expected 0 known peers after wildcard addrs, got %d", len(mgr.knownPeers))
+	}
+}
+
+func TestMergeRejectsEmptyAddr(t *testing.T) {
+	mgr := makeTestManager(t)
+
+	info := validPeerInfo(t, "")
+	mgr.mergeDiscoveredPeers([]*pb.PeerInfo{info}, "sender")
+
+	mgr.mu.Lock()
+	defer mgr.mu.Unlock()
+	if len(mgr.knownPeers) != 0 {
+		t.Fatalf("expected 0 known peers after empty addr, got %d", len(mgr.knownPeers))
+	}
+}
+
+func TestMergeRejectsNonReachable(t *testing.T) {
+	mgr := makeTestManager(t)
+
+	info := validPeerInfo(t, "10.0.0.1:4000")
+	info.Reachable = false
+	mgr.mergeDiscoveredPeers([]*pb.PeerInfo{info}, "sender")
+
+	mgr.mu.Lock()
+	defer mgr.mu.Unlock()
+	if len(mgr.knownPeers) != 0 {
+		t.Fatalf("expected 0 known peers after non-reachable, got %d", len(mgr.knownPeers))
+	}
+}
+
+func TestMergeRejectsInvalidPubkeySize(t *testing.T) {
+	mgr := makeTestManager(t)
+
+	info := &pb.PeerInfo{
+		NodeId:        "abcd",
+		Addr:          "10.0.0.1:4000",
+		Reachable:     true,
+		Ed25519Pubkey: []byte("tooshort"),
+		LastSeen:      1000,
+	}
+	mgr.mergeDiscoveredPeers([]*pb.PeerInfo{info}, "sender")
+
+	mgr.mu.Lock()
+	defer mgr.mu.Unlock()
+	if len(mgr.knownPeers) != 0 {
+		t.Fatalf("expected 0 known peers after invalid pubkey size, got %d", len(mgr.knownPeers))
+	}
+}
+
+func TestMergeSkipsSelf(t *testing.T) {
+	mgr := makeTestManager(t)
+
+	// Build a PeerInfo with this manager's own node ID and key
+	info := &pb.PeerInfo{
+		NodeId:        mgr.id.NodeID,
+		Addr:          "10.0.0.1:4000",
+		Reachable:     true,
+		Ed25519Pubkey: mgr.id.PublicKey,
+		LastSeen:      1000,
+	}
+	mgr.mergeDiscoveredPeers([]*pb.PeerInfo{info}, "sender")
+
+	mgr.mu.Lock()
+	defer mgr.mu.Unlock()
+	if len(mgr.knownPeers) != 0 {
+		t.Fatalf("expected 0 known peers after self-info, got %d", len(mgr.knownPeers))
+	}
+}
+
+func TestMergeAcceptsValidPeer(t *testing.T) {
+	mgr := makeTestManager(t)
+
+	info := validPeerInfo(t, "10.0.0.1:4000")
+	mgr.mergeDiscoveredPeers([]*pb.PeerInfo{info}, "sender")
+
+	mgr.mu.Lock()
+	defer mgr.mu.Unlock()
+	if len(mgr.knownPeers) != 1 {
+		t.Fatalf("expected 1 known peer, got %d", len(mgr.knownPeers))
+	}
+	rec := mgr.knownPeers[info.NodeId]
+	if rec == nil {
+		t.Fatal("peer not found in knownPeers")
+	}
+	if rec.Addr != "10.0.0.1:4000" {
+		t.Fatalf("expected addr 10.0.0.1:4000, got %s", rec.Addr)
+	}
+}
+
+func TestMergeUpdatesOnlyIfNewer(t *testing.T) {
+	mgr := makeTestManager(t)
+
+	info := validPeerInfo(t, "10.0.0.1:4000")
+	info.LastSeen = 2000
+	mgr.mergeDiscoveredPeers([]*pb.PeerInfo{info}, "sender")
+
+	// Send older update — should NOT change addr
+	info2 := &pb.PeerInfo{
+		NodeId:        info.NodeId,
+		Addr:          "10.0.0.2:5000",
+		Reachable:     true,
+		Ed25519Pubkey: info.Ed25519Pubkey,
+		LastSeen:      1000, // older
+	}
+	mgr.mergeDiscoveredPeers([]*pb.PeerInfo{info2}, "sender")
+
+	func() {
+		mgr.mu.Lock()
+		defer mgr.mu.Unlock()
+		rec := mgr.knownPeers[info.NodeId]
+		if rec.Addr != "10.0.0.1:4000" {
+			t.Fatalf("addr changed to %s despite older LastSeen", rec.Addr)
+		}
+	}()
+
+	// Send newer update — SHOULD change addr
+	info3 := &pb.PeerInfo{
+		NodeId:        info.NodeId,
+		Addr:          "10.0.0.3:6000",
+		Reachable:     true,
+		Ed25519Pubkey: info.Ed25519Pubkey,
+		LastSeen:      3000, // newer
+	}
+	mgr.mergeDiscoveredPeers([]*pb.PeerInfo{info3}, "sender")
+
+	mgr.mu.Lock()
+	defer mgr.mu.Unlock()
+	rec := mgr.knownPeers[info.NodeId]
+	if rec.Addr != "10.0.0.3:6000" {
+		t.Fatalf("addr not updated to 10.0.0.3:6000, got %s", rec.Addr)
+	}
+}
+
+func TestBuildPeerInfoExcludesWildcard(t *testing.T) {
+	mgr := makeTestManager(t)
+
+	// Manually insert a known peer with a wildcard addr
+	info := validPeerInfo(t, "10.0.0.1:4000")
+	mgr.mergeDiscoveredPeers([]*pb.PeerInfo{info}, "sender")
+
+	wildcardInfo := validPeerInfo(t, "0.0.0.0:4000")
+	// Force-insert with wildcard addr (bypassing merge validation)
+	mgr.mu.Lock()
+	mgr.knownPeers[wildcardInfo.NodeId] = &PeerRecord{
+		NodeID:    wildcardInfo.NodeId,
+		Addr:      "0.0.0.0:4000",
+		Reachable: true,
+		PublicKey: "aa",
+		LastSeen:  1000,
+	}
+	mgr.mu.Unlock()
+
+	infos := mgr.buildPeerInfoList("nobody")
+	// Should include the valid peer but NOT the wildcard peer (self may also be excluded)
+	for _, pi := range infos {
+		if pi.Addr == "0.0.0.0:4000" {
+			t.Fatal("buildPeerInfoList should exclude wildcard addresses")
+		}
+	}
+}
+
+func TestIsInvalidPeerAddr(t *testing.T) {
+	cases := []struct {
+		addr    string
+		invalid bool
+	}{
+		{"0.0.0.0:4000", true},
+		{"[::]:4000", true},
+		{":4000", true},
+		{"not-a-hostport", true},
+		{"just-a-host", true},
+		{"10.0.0.1:4000", false},
+		{"127.0.0.1:4000", false},
+		{"example.com:4000", false},
+	}
+	for _, tc := range cases {
+		got := isInvalidPeerAddr(tc.addr)
+		if got != tc.invalid {
+			t.Errorf("isInvalidPeerAddr(%q) = %v, want %v", tc.addr, got, tc.invalid)
+		}
+	}
+}

--- a/internal/transport/discovery_test.go
+++ b/internal/transport/discovery_test.go
@@ -1,0 +1,628 @@
+package transport_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"micelio/internal/config"
+	"micelio/internal/identity"
+	"micelio/internal/partyline"
+	"micelio/internal/transport"
+)
+
+// TestThreeNodeMesh verifies automatic mesh formation via PeerExchange.
+// Topology: A knows B (bootstrap), C knows B (bootstrap), but A does NOT know C.
+// After PeerExchange, A should discover C and dial it, forming a full mesh.
+func TestThreeNodeMesh(t *testing.T) {
+	type testNode struct {
+		id      *identity.Identity
+		hub     *partyline.Hub
+		mgr     *transport.Manager
+		ctx     context.Context
+		cancel  context.CancelFunc
+		session *partyline.Session
+	}
+
+	makeNode := func(name string) testNode {
+		id, err := identity.Load(t.TempDir())
+		if err != nil {
+			t.Fatalf("identity %s: %v", name, err)
+		}
+		hub := partyline.NewHub(name)
+		ctx, cancel := context.WithCancel(context.Background())
+		return testNode{id: id, hub: hub, ctx: ctx, cancel: cancel}
+	}
+
+	cleanup := func(n *testNode) {
+		if n.session != nil {
+			n.hub.Leave(n.session)
+		}
+		if n.mgr != nil {
+			n.mgr.Stop()
+		}
+		n.cancel()
+		n.hub.Stop()
+	}
+
+	nodeB := makeNode("node-b")
+	nodeA := makeNode("node-a")
+	nodeC := makeNode("node-c")
+
+	defer func() {
+		cleanup(&nodeC)
+		cleanup(&nodeA)
+		cleanup(&nodeB)
+	}()
+
+	// Fast intervals for testing
+	fastExchange := config.Duration{Duration: 1 * time.Second}
+	fastDiscovery := config.Duration{Duration: 1 * time.Second}
+
+	// Start B (center) — listens, no bootstrap
+	cfgB := &config.Config{
+		Node: config.NodeConfig{Name: "node-b"},
+		Network: config.NetworkConfig{
+			Listen:            "127.0.0.1:0",
+			MaxPeers:          15,
+			ExchangeInterval:  fastExchange,
+			DiscoveryInterval: fastDiscovery,
+		},
+	}
+	mgrB, err := transport.NewManager(cfgB, nodeB.id, nodeB.hub, nil)
+	if err != nil {
+		t.Fatalf("manager B: %v", err)
+	}
+	nodeB.mgr = mgrB
+	go nodeB.hub.Run()
+	go mgrB.Start(nodeB.ctx)
+
+	// Wait for B's listener
+	deadline := time.Now().Add(5 * time.Second)
+	for mgrB.Addr() == "" && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if mgrB.Addr() == "" {
+		t.Fatal("node B failed to start listener")
+	}
+	addrB := mgrB.Addr()
+
+	// Start A — listens, bootstraps to B
+	cfgA := &config.Config{
+		Node: config.NodeConfig{Name: "node-a"},
+		Network: config.NetworkConfig{
+			Listen:            "127.0.0.1:0",
+			Bootstrap:         []string{addrB},
+			MaxPeers:          15,
+			ExchangeInterval:  fastExchange,
+			DiscoveryInterval: fastDiscovery,
+		},
+	}
+	mgrA, err := transport.NewManager(cfgA, nodeA.id, nodeA.hub, nil)
+	if err != nil {
+		t.Fatalf("manager A: %v", err)
+	}
+	nodeA.mgr = mgrA
+	go nodeA.hub.Run()
+	go mgrA.Start(nodeA.ctx)
+
+	// Wait for A↔B connection
+	deadline = time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if mgrA.PeerCount() >= 1 && mgrB.PeerCount() >= 1 {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if mgrA.PeerCount() == 0 || mgrB.PeerCount() == 0 {
+		t.Fatalf("A↔B not connected: A=%d B=%d", mgrA.PeerCount(), mgrB.PeerCount())
+	}
+
+	// Start C — listens, bootstraps to B (does NOT know A)
+	cfgC := &config.Config{
+		Node: config.NodeConfig{Name: "node-c"},
+		Network: config.NetworkConfig{
+			Listen:            "127.0.0.1:0",
+			Bootstrap:         []string{addrB},
+			MaxPeers:          15,
+			ExchangeInterval:  fastExchange,
+			DiscoveryInterval: fastDiscovery,
+		},
+	}
+	mgrC, err := transport.NewManager(cfgC, nodeC.id, nodeC.hub, nil)
+	if err != nil {
+		t.Fatalf("manager C: %v", err)
+	}
+	nodeC.mgr = mgrC
+	go nodeC.hub.Run()
+	go mgrC.Start(nodeC.ctx)
+
+	// Wait for full mesh: each node has 2 peers (A↔B, B↔C, A↔C via discovery)
+	deadline = time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		if mgrA.PeerCount() == 2 && mgrB.PeerCount() == 2 && mgrC.PeerCount() == 2 {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if mgrA.PeerCount() != 2 || mgrB.PeerCount() != 2 || mgrC.PeerCount() != 2 {
+		t.Fatalf("mesh not formed: A=%d B=%d C=%d (want 2,2,2)",
+			mgrA.PeerCount(), mgrB.PeerCount(), mgrC.PeerCount())
+	}
+
+	// Verify chat works across the full mesh: A → B and C
+	nodeA.session = nodeA.hub.Join("alice")
+	nodeB.session = nodeB.hub.Join("bob")
+	nodeC.session = nodeC.hub.Join("carol")
+
+	drainFor(nodeA.session.Send, 200*time.Millisecond)
+	drainFor(nodeB.session.Send, 200*time.Millisecond)
+	drainFor(nodeC.session.Send, 200*time.Millisecond)
+
+	nodeA.hub.Broadcast(nodeA.session, "hello mesh")
+
+	msgB := waitForMsg(nodeB.session.Send, 5*time.Second, "alice", "hello mesh")
+	if msgB == "" {
+		t.Error("node B did not receive message from A")
+	}
+	msgC := waitForMsg(nodeC.session.Send, 5*time.Second, "alice", "hello mesh")
+	if msgC == "" {
+		t.Error("node C did not receive message from A")
+	}
+}
+
+// TestChainToMesh verifies that a linear chain A→B→C→D→E (bootstrap only)
+// converges into a full mesh via PeerExchange, and that a message from A
+// reaches E (which has no direct bootstrap connection to A).
+func TestChainToMesh(t *testing.T) {
+	const N = 5
+	names := []string{"A", "B", "C", "D", "E"}
+	nicks := []string{"alice", "bob", "carol", "dave", "eve"}
+
+	type testNode struct {
+		id      *identity.Identity
+		hub     *partyline.Hub
+		mgr     *transport.Manager
+		ctx     context.Context
+		cancel  context.CancelFunc
+		session *partyline.Session
+	}
+
+	nodes := make([]testNode, N)
+	for i := 0; i < N; i++ {
+		id, err := identity.Load(t.TempDir())
+		if err != nil {
+			t.Fatalf("identity %s: %v", names[i], err)
+		}
+		hub := partyline.NewHub("node-" + names[i])
+		ctx, cancel := context.WithCancel(context.Background())
+		nodes[i] = testNode{id: id, hub: hub, ctx: ctx, cancel: cancel}
+	}
+
+	defer func() {
+		for i := N - 1; i >= 0; i-- {
+			if nodes[i].session != nil {
+				nodes[i].hub.Leave(nodes[i].session)
+			}
+			if nodes[i].mgr != nil {
+				nodes[i].mgr.Stop()
+			}
+			nodes[i].cancel()
+			nodes[i].hub.Stop()
+		}
+	}()
+
+	fastExchange := config.Duration{Duration: 1 * time.Second}
+	fastDiscovery := config.Duration{Duration: 1 * time.Second}
+
+	// Start nodes from E→A so each can bootstrap to the next.
+	// E (index 4) has no bootstrap; D bootstraps to E; ... A bootstraps to B.
+	addrs := make([]string, N)
+	for i := N - 1; i >= 0; i-- {
+		var bootstrap []string
+		if i < N-1 {
+			bootstrap = []string{addrs[i+1]}
+		}
+		cfg := &config.Config{
+			Node: config.NodeConfig{Name: "node-" + names[i]},
+			Network: config.NetworkConfig{
+				Listen:            "127.0.0.1:0",
+				MaxPeers:          15,
+				Bootstrap:         bootstrap,
+				ExchangeInterval:  fastExchange,
+				DiscoveryInterval: fastDiscovery,
+			},
+		}
+		mgr, err := transport.NewManager(cfg, nodes[i].id, nodes[i].hub, nil)
+		if err != nil {
+			t.Fatalf("manager %s: %v", names[i], err)
+		}
+		nodes[i].mgr = mgr
+		go nodes[i].hub.Run()
+		go mgr.Start(nodes[i].ctx)
+
+		// Wait for listener
+		deadline := time.Now().Add(5 * time.Second)
+		for mgr.Addr() == "" && time.Now().Before(deadline) {
+			time.Sleep(10 * time.Millisecond)
+		}
+		if mgr.Addr() == "" {
+			t.Fatalf("node %s failed to start listener", names[i])
+		}
+		addrs[i] = mgr.Addr()
+	}
+
+	// Wait for the initial chain links to form: each adjacent pair connected.
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		allLinked := true
+		for i := 0; i < N; i++ {
+			if nodes[i].mgr.PeerCount() == 0 {
+				allLinked = false
+				break
+			}
+		}
+		if allLinked {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	for i := 0; i < N; i++ {
+		if nodes[i].mgr.PeerCount() == 0 {
+			t.Fatalf("node %s has 0 peers (chain not formed)", names[i])
+		}
+	}
+
+	// Wait for full mesh: each node has N-1 = 4 peers.
+	deadline = time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		allFull := true
+		for i := 0; i < N; i++ {
+			if nodes[i].mgr.PeerCount() < N-1 {
+				allFull = false
+				break
+			}
+		}
+		if allFull {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	for i := 0; i < N; i++ {
+		if nodes[i].mgr.PeerCount() != N-1 {
+			counts := ""
+			for j := 0; j < N; j++ {
+				if j > 0 {
+					counts += " "
+				}
+				counts += fmt.Sprintf("%s=%d", names[j], nodes[j].mgr.PeerCount())
+			}
+			t.Fatalf("mesh not formed: %s (want %d each)", counts, N-1)
+		}
+	}
+
+	// Join sessions and drain join notifications
+	for i := 0; i < N; i++ {
+		nodes[i].session = nodes[i].hub.Join(nicks[i])
+	}
+	for i := 0; i < N; i++ {
+		drainFor(nodes[i].session.Send, 200*time.Millisecond)
+	}
+
+	// A sends a message — verify E receives it
+	nodes[0].hub.Broadcast(nodes[0].session, "hello from the edge")
+
+	msg := waitForMsg(nodes[N-1].session.Send, 5*time.Second, nicks[0], "hello from the edge")
+	if msg == "" {
+		t.Fatal("node E did not receive message from A")
+	}
+
+	// Also verify all intermediate nodes received it
+	for i := 1; i < N-1; i++ {
+		msg := waitForMsg(nodes[i].session.Send, 5*time.Second, nicks[0], "hello from the edge")
+		if msg == "" {
+			t.Fatalf("node %s did not receive message from A", names[i])
+		}
+	}
+}
+
+// TestPeerRecordString verifies the Stringer implementation.
+func TestPeerRecordString(t *testing.T) {
+	rec := &transport.PeerRecord{
+		NodeID:    "abcdef123456789",
+		Addr:      "10.0.0.1:9000",
+		Reachable: true,
+		FailCount: 3,
+	}
+	s := rec.String()
+	if s == "" {
+		t.Fatal("expected non-empty string")
+	}
+	// Should contain truncated node ID
+	expected := "PeerRecord{abcdef123456"
+	if len(s) < len(expected) {
+		t.Fatalf("string too short: %s", s)
+	}
+	if s[:len(expected)] != expected {
+		t.Fatalf("unexpected prefix: %s", s)
+	}
+
+	// Short NodeID should not panic
+	short := &transport.PeerRecord{NodeID: "abc"}
+	if short.String() == "" {
+		t.Fatal("short NodeID String() returned empty")
+	}
+}
+
+// TestMaxPeersEnforcement verifies that MaxPeers is enforced.
+// We set MaxPeers=1 on a center node and connect 2 spokes. Only 1 should succeed.
+func TestMaxPeersEnforcement(t *testing.T) {
+	type testNode struct {
+		id     *identity.Identity
+		hub    *partyline.Hub
+		mgr    *transport.Manager
+		ctx    context.Context
+		cancel context.CancelFunc
+	}
+
+	makeNode := func(name string) testNode {
+		id, err := identity.Load(t.TempDir())
+		if err != nil {
+			t.Fatalf("identity %s: %v", name, err)
+		}
+		hub := partyline.NewHub(name)
+		ctx, cancel := context.WithCancel(context.Background())
+		return testNode{id: id, hub: hub, ctx: ctx, cancel: cancel}
+	}
+
+	center := makeNode("center")
+	spoke1 := makeNode("spoke1")
+	spoke2 := makeNode("spoke2")
+
+	defer func() {
+		for _, n := range []*testNode{&spoke2, &spoke1, &center} {
+			if n.mgr != nil {
+				n.mgr.Stop()
+			}
+			n.cancel()
+			n.hub.Stop()
+		}
+	}()
+
+	// Center with MaxPeers=1
+	cfgCenter := &config.Config{
+		Node:    config.NodeConfig{Name: "center"},
+		Network: config.NetworkConfig{Listen: "127.0.0.1:0", MaxPeers: 1},
+	}
+	mgrCenter, err := transport.NewManager(cfgCenter, center.id, center.hub, nil)
+	if err != nil {
+		t.Fatalf("manager center: %v", err)
+	}
+	center.mgr = mgrCenter
+	go center.hub.Run()
+	go mgrCenter.Start(center.ctx)
+
+	deadline := time.Now().Add(5 * time.Second)
+	for mgrCenter.Addr() == "" && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	addr := mgrCenter.Addr()
+
+	// Connect spoke1
+	cfgS1 := &config.Config{
+		Node:    config.NodeConfig{Name: "spoke1"},
+		Network: config.NetworkConfig{Bootstrap: []string{addr}},
+	}
+	mgrS1, err := transport.NewManager(cfgS1, spoke1.id, spoke1.hub, nil)
+	if err != nil {
+		t.Fatalf("manager spoke1: %v", err)
+	}
+	spoke1.mgr = mgrS1
+	go spoke1.hub.Run()
+	go mgrS1.Start(spoke1.ctx)
+
+	// Wait for spoke1 to connect
+	deadline = time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if mgrCenter.PeerCount() >= 1 {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if mgrCenter.PeerCount() != 1 {
+		t.Fatalf("center has %d peers, want 1", mgrCenter.PeerCount())
+	}
+
+	// Connect spoke2 — should be rejected by center
+	cfgS2 := &config.Config{
+		Node:    config.NodeConfig{Name: "spoke2"},
+		Network: config.NetworkConfig{Bootstrap: []string{addr}},
+	}
+	mgrS2, err := transport.NewManager(cfgS2, spoke2.id, spoke2.hub, nil)
+	if err != nil {
+		t.Fatalf("manager spoke2: %v", err)
+	}
+	spoke2.mgr = mgrS2
+	go spoke2.hub.Run()
+	go mgrS2.Start(spoke2.ctx)
+
+	// Give spoke2 time to attempt connection
+	time.Sleep(2 * time.Second)
+
+	// Center should still have exactly 1 peer
+	if mgrCenter.PeerCount() != 1 {
+		t.Fatalf("center has %d peers after MaxPeers enforcement, want 1", mgrCenter.PeerCount())
+	}
+}
+
+// TestTenNodeMultiIP verifies discovery across 10 nodes each listening on a
+// different loopback address (127.0.0.1 through 127.0.0.10). Only adjacent
+// nodes know each other via bootstrap (chain topology). PeerExchange must
+// propagate all addresses so every node discovers and dials the others,
+// converging into a full 10-node mesh.
+func TestTenNodeMultiIP(t *testing.T) {
+	const N = 10
+
+	type testNode struct {
+		id      *identity.Identity
+		hub     *partyline.Hub
+		mgr     *transport.Manager
+		ctx     context.Context
+		cancel  context.CancelFunc
+		session *partyline.Session
+	}
+
+	nodes := make([]testNode, N)
+	for i := 0; i < N; i++ {
+		id, err := identity.Load(t.TempDir())
+		if err != nil {
+			t.Fatalf("identity node-%d: %v", i, err)
+		}
+		hub := partyline.NewHub(fmt.Sprintf("node-%d", i))
+		ctx, cancel := context.WithCancel(context.Background())
+		nodes[i] = testNode{id: id, hub: hub, ctx: ctx, cancel: cancel}
+	}
+
+	defer func() {
+		for i := N - 1; i >= 0; i-- {
+			if nodes[i].session != nil {
+				nodes[i].hub.Leave(nodes[i].session)
+			}
+			if nodes[i].mgr != nil {
+				nodes[i].mgr.Stop()
+			}
+			nodes[i].cancel()
+			nodes[i].hub.Stop()
+		}
+	}()
+
+	fastExchange := config.Duration{Duration: 1 * time.Second}
+	fastDiscovery := config.Duration{Duration: 1 * time.Second}
+
+	// Start nodes from N-1 down to 0 so each can bootstrap to the next.
+	// Each node listens on 127.0.0.(i+1):0
+	addrs := make([]string, N)
+	for i := N - 1; i >= 0; i-- {
+		listenIP := fmt.Sprintf("127.0.0.%d", i+1)
+
+		var bootstrap []string
+		if i < N-1 {
+			bootstrap = []string{addrs[i+1]}
+		}
+
+		cfg := &config.Config{
+			Node: config.NodeConfig{Name: fmt.Sprintf("node-%d", i)},
+			Network: config.NetworkConfig{
+				Listen:            listenIP + ":0",
+				MaxPeers:          15,
+				Bootstrap:         bootstrap,
+				ExchangeInterval:  fastExchange,
+				DiscoveryInterval: fastDiscovery,
+			},
+		}
+		mgr, err := transport.NewManager(cfg, nodes[i].id, nodes[i].hub, nil)
+		if err != nil {
+			t.Fatalf("manager node-%d: %v", i, err)
+		}
+		nodes[i].mgr = mgr
+		go nodes[i].hub.Run()
+		go mgr.Start(nodes[i].ctx)
+
+		deadline := time.Now().Add(5 * time.Second)
+		for mgr.Addr() == "" && time.Now().Before(deadline) {
+			time.Sleep(10 * time.Millisecond)
+		}
+		if mgr.Addr() == "" {
+			t.Fatalf("node-%d failed to start listener on %s", i, listenIP)
+		}
+		addrs[i] = mgr.Addr()
+		t.Logf("node-%d listening on %s", i, addrs[i])
+	}
+
+	// Wait for chain links: every node has at least 1 peer
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		allLinked := true
+		for i := 0; i < N; i++ {
+			if nodes[i].mgr.PeerCount() == 0 {
+				allLinked = false
+				break
+			}
+		}
+		if allLinked {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	for i := 0; i < N; i++ {
+		if nodes[i].mgr.PeerCount() == 0 {
+			t.Fatalf("node-%d has 0 peers (chain not formed)", i)
+		}
+	}
+
+	// Wait for full mesh: each node has N-1 = 9 peers
+	deadline = time.Now().Add(45 * time.Second)
+	for time.Now().Before(deadline) {
+		allFull := true
+		for i := 0; i < N; i++ {
+			if nodes[i].mgr.PeerCount() < N-1 {
+				allFull = false
+				break
+			}
+		}
+		if allFull {
+			break
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	for i := 0; i < N; i++ {
+		if nodes[i].mgr.PeerCount() != N-1 {
+			counts := ""
+			for j := 0; j < N; j++ {
+				if j > 0 {
+					counts += " "
+				}
+				counts += fmt.Sprintf("node-%d=%d", j, nodes[j].mgr.PeerCount())
+			}
+			t.Fatalf("mesh not formed: %s (want %d each)", counts, N-1)
+		}
+	}
+
+	// Join sessions and drain
+	nicks := []string{"alice", "bob", "carol", "dave", "eve", "frank", "grace", "heidi", "ivan", "judy"}
+	for i := 0; i < N; i++ {
+		nodes[i].session = nodes[i].hub.Join(nicks[i])
+	}
+	for i := 0; i < N; i++ {
+		drainFor(nodes[i].session.Send, 200*time.Millisecond)
+	}
+
+	// Node 0 (127.0.0.1) sends a message — verify node 9 (127.0.0.10) receives it
+	nodes[0].hub.Broadcast(nodes[0].session, "hello across loopbacks")
+
+	msg := waitForMsg(nodes[N-1].session.Send, 5*time.Second, nicks[0], "hello across loopbacks")
+	if msg == "" {
+		t.Fatal("node-9 (127.0.0.10) did not receive message from node-0 (127.0.0.1)")
+	}
+
+	// Verify all other nodes received it too
+	for i := 1; i < N-1; i++ {
+		msg := waitForMsg(nodes[i].session.Send, 5*time.Second, nicks[0], "hello across loopbacks")
+		if msg == "" {
+			t.Fatalf("node-%d did not receive message from node-0", i)
+		}
+	}
+
+	// Node 9 (127.0.0.10) sends back — verify node 0 (127.0.0.1) receives it
+	for i := 0; i < N; i++ {
+		drainFor(nodes[i].session.Send, 100*time.Millisecond)
+	}
+	nodes[N-1].hub.Broadcast(nodes[N-1].session, "reply from the edge")
+
+	msg = waitForMsg(nodes[0].session.Send, 5*time.Second, nicks[N-1], "reply from the edge")
+	if msg == "" {
+		t.Fatal("node-0 (127.0.0.1) did not receive message from node-9 (127.0.0.10)")
+	}
+}
+

--- a/internal/transport/manager.go
+++ b/internal/transport/manager.go
@@ -14,6 +14,7 @@ import (
 	"micelio/internal/config"
 	"micelio/internal/identity"
 	"micelio/internal/partyline"
+	"micelio/internal/store"
 )
 
 // Manager manages all peer connections for a node.
@@ -22,11 +23,15 @@ type Manager struct {
 	id       *identity.Identity
 	hub      *partyline.Hub
 	noiseKey noise.DHKey
+	store    store.Store // nil in tests
 
-	mu         sync.Mutex
-	peers      map[string]*Peer // nodeID → Peer
-	listener   net.Listener
-	listenAddr string // actual bound address (set after Listen)
+	mu             sync.Mutex
+	peers          map[string]*Peer       // nodeID → Peer
+	knownPeers     map[string]*PeerRecord // discovered peers
+	dialing        map[string]bool        // nodeIDs being dialed
+	bootstrapAddrs map[string]bool        // addresses managed by dialWithBackoff
+	listener       net.Listener
+	listenAddr     string // actual bound address (set after Listen)
 
 	remoteSend chan partyline.RemoteMsg
 	done       chan struct{}
@@ -35,7 +40,8 @@ type Manager struct {
 
 // NewManager creates a transport manager.
 // It derives X25519 keys from the identity and registers with the hub for outgoing messages.
-func NewManager(cfg *config.Config, id *identity.Identity, hub *partyline.Hub) (*Manager, error) {
+// The store parameter may be nil (e.g. in tests); discovery works in-memory only.
+func NewManager(cfg *config.Config, id *identity.Identity, hub *partyline.Hub, st store.Store) (*Manager, error) {
 	noiseKey, err := mcrypto.EdToNoiseKeypair(id)
 	if err != nil {
 		return nil, fmt.Errorf("deriving noise keypair: %w", err)
@@ -44,15 +50,28 @@ func NewManager(cfg *config.Config, id *identity.Identity, hub *partyline.Hub) (
 	remoteSend := make(chan partyline.RemoteMsg, 64)
 	hub.SetRemoteSend(remoteSend)
 
-	return &Manager{
-		cfg:        cfg,
-		id:         id,
-		hub:        hub,
-		noiseKey:   noiseKey,
-		peers:      make(map[string]*Peer),
-		remoteSend: remoteSend,
-		done:       make(chan struct{}),
-	}, nil
+	bootstrapSet := make(map[string]bool, len(cfg.Network.Bootstrap))
+	for _, addr := range cfg.Network.Bootstrap {
+		bootstrapSet[addr] = true
+	}
+
+	mgr := &Manager{
+		cfg:            cfg,
+		id:             id,
+		hub:            hub,
+		noiseKey:       noiseKey,
+		store:          st,
+		peers:          make(map[string]*Peer),
+		knownPeers:     make(map[string]*PeerRecord),
+		dialing:        make(map[string]bool),
+		bootstrapAddrs: bootstrapSet,
+		remoteSend:     remoteSend,
+		done:           make(chan struct{}),
+	}
+
+	mgr.loadKnownPeers()
+
+	return mgr, nil
 }
 
 // Start begins listening for inbound connections and dialing bootstrap peers.
@@ -74,6 +93,8 @@ func (m *Manager) Start(ctx context.Context) error {
 	}
 
 	go m.fanoutLoop(ctx)
+	go m.exchangeLoop(ctx)
+	go m.discoveryLoop(ctx)
 
 	<-ctx.Done()
 	return nil
@@ -131,6 +152,19 @@ func (m *Manager) listenLoop(ctx context.Context) {
 }
 
 func (m *Manager) handleInbound(conn net.Conn) {
+	// Quick capacity check before expensive handshake.
+	// The definitive check is in addPeer; this avoids wasted crypto work.
+	if m.cfg.Network.MaxPeers > 0 {
+		m.mu.Lock()
+		atCapacity := len(m.peers) >= m.cfg.Network.MaxPeers
+		m.mu.Unlock()
+		if atCapacity {
+			log.Printf("rejecting inbound connection from %s: at MaxPeers capacity", conn.RemoteAddr())
+			conn.Close()
+			return
+		}
+	}
+
 	nc, peerX25519, err := Handshake(conn, false, m.noiseKey)
 	if err != nil {
 		log.Printf("inbound noise handshake from %s: %v", conn.RemoteAddr(), err)
@@ -145,13 +179,14 @@ func (m *Manager) handleInbound(conn net.Conn) {
 		return
 	}
 
-	if !m.addPeer(peer) {
-		log.Printf("duplicate peer %s, dropping inbound", peer.NodeID)
+	if reason := m.addPeer(peer); reason != "" {
+		log.Printf("rejecting inbound peer %s: %s", peer.NodeID, reason)
 		nc.Close()
 		return
 	}
 
 	log.Printf("peer connected (inbound): %s", peer.NodeID)
+	m.onPeerConnected(peer)
 	peer.Run()
 	m.removePeer(peer.NodeID)
 	log.Printf("peer disconnected: %s", peer.NodeID)
@@ -206,12 +241,13 @@ func (m *Manager) dial(addr string) error {
 		return fmt.Errorf("hello exchange: %w", err)
 	}
 
-	if !m.addPeer(peer) {
+	if reason := m.addPeer(peer); reason != "" {
 		nc.Close()
-		return fmt.Errorf("duplicate peer %s", peer.NodeID)
+		return fmt.Errorf("peer %s rejected: %s", peer.NodeID, reason)
 	}
 
 	log.Printf("peer connected (outbound): %s", peer.NodeID)
+	m.onPeerConnected(peer)
 	peer.Run()
 	m.removePeer(peer.NodeID)
 	log.Printf("peer disconnected: %s", peer.NodeID)
@@ -235,14 +271,19 @@ func (m *Manager) fanoutLoop(ctx context.Context) {
 	}
 }
 
-func (m *Manager) addPeer(p *Peer) bool {
+// addPeer adds a peer to the peers map. Returns "" on success, or a reason on failure.
+func (m *Manager) addPeer(p *Peer) string {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if _, exists := m.peers[p.NodeID]; exists {
-		return false
+		return "duplicate"
 	}
+	if m.cfg.Network.MaxPeers > 0 && len(m.peers) >= m.cfg.Network.MaxPeers {
+		return "max peers reached"
+	}
+	p.onPeerExchange = m.peerExchangeHandler()
 	m.peers[p.NodeID] = p
-	return true
+	return ""
 }
 
 func (m *Manager) removePeer(nodeID string) {
@@ -252,12 +293,35 @@ func (m *Manager) removePeer(nodeID string) {
 }
 
 func (m *Manager) helloConfig() HelloConfig {
-	m.mu.Lock()
-	addr := m.listenAddr
-	m.mu.Unlock()
+	addr := m.advertiseAddr()
 	return HelloConfig{
 		Tags:       m.cfg.Node.Tags,
 		Reachable:  addr != "",
 		ListenAddr: addr,
 	}
+}
+
+// advertiseAddr returns the address to advertise to peers.
+// It prefers cfg.Network.AdvertiseAddr, then falls back to the bound
+// listen address — but only if the listen host is not a wildcard.
+func (m *Manager) advertiseAddr() string {
+	if a := m.cfg.Network.AdvertiseAddr; a != "" {
+		return a
+	}
+	m.mu.Lock()
+	addr := m.listenAddr
+	m.mu.Unlock()
+	if addr == "" {
+		return ""
+	}
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		// If the listen address is not in host:port form, don't advertise it.
+		return ""
+	}
+	// Don't advertise wildcard addresses — peers can't reach 0.0.0.0.
+	if host == "0.0.0.0" || host == "::" || host == "" {
+		return ""
+	}
+	return addr
 }

--- a/internal/transport/manager_internal_test.go
+++ b/internal/transport/manager_internal_test.go
@@ -1,0 +1,55 @@
+package transport
+
+import (
+	"testing"
+
+	"micelio/internal/config"
+	"micelio/internal/identity"
+	"micelio/internal/partyline"
+)
+
+func TestAdvertiseAddr(t *testing.T) {
+	dir := t.TempDir()
+	id, err := identity.Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hub := partyline.NewHub("test")
+
+	tests := []struct {
+		name          string
+		advertiseAddr string
+		listenAddr    string // simulated bound address
+		want          string
+	}{
+		{"explicit_advertise_addr", "1.2.3.4:9000", "0.0.0.0:9000", "1.2.3.4:9000"},
+		{"non_wildcard_listen", "", "127.0.0.1:9000", "127.0.0.1:9000"},
+		{"wildcard_0000", "", "0.0.0.0:9000", ""},
+		{"wildcard_ipv6", "", "[::]:9000", ""},
+		{"no_listen", "", "", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &config.Config{
+				Node: config.NodeConfig{Name: "test"},
+				Network: config.NetworkConfig{
+					AdvertiseAddr: tc.advertiseAddr,
+				},
+			}
+			mgr, err := NewManager(cfg, id, hub, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// Simulate the bound listen address
+			mgr.mu.Lock()
+			mgr.listenAddr = tc.listenAddr
+			mgr.mu.Unlock()
+
+			got := mgr.advertiseAddr()
+			if got != tc.want {
+				t.Errorf("advertiseAddr() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/proto/micelio.pb.go
+++ b/pkg/proto/micelio.pb.go
@@ -348,6 +348,128 @@ func (x *ChatMessage) GetTimestamp() uint64 {
 	return 0
 }
 
+// PeerInfo describes a known peer for exchange.
+type PeerInfo struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	NodeId        string                 `protobuf:"bytes,1,opt,name=node_id,json=nodeId,proto3" json:"node_id,omitempty"`
+	Addr          string                 `protobuf:"bytes,2,opt,name=addr,proto3" json:"addr,omitempty"`
+	Reachable     bool                   `protobuf:"varint,3,opt,name=reachable,proto3" json:"reachable,omitempty"`
+	Ed25519Pubkey []byte                 `protobuf:"bytes,4,opt,name=ed25519_pubkey,json=ed25519Pubkey,proto3" json:"ed25519_pubkey,omitempty"`
+	LastSeen      uint64                 `protobuf:"varint,5,opt,name=last_seen,json=lastSeen,proto3" json:"last_seen,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PeerInfo) Reset() {
+	*x = PeerInfo{}
+	mi := &file_proto_micelio_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PeerInfo) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PeerInfo) ProtoMessage() {}
+
+func (x *PeerInfo) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_micelio_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PeerInfo.ProtoReflect.Descriptor instead.
+func (*PeerInfo) Descriptor() ([]byte, []int) {
+	return file_proto_micelio_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *PeerInfo) GetNodeId() string {
+	if x != nil {
+		return x.NodeId
+	}
+	return ""
+}
+
+func (x *PeerInfo) GetAddr() string {
+	if x != nil {
+		return x.Addr
+	}
+	return ""
+}
+
+func (x *PeerInfo) GetReachable() bool {
+	if x != nil {
+		return x.Reachable
+	}
+	return false
+}
+
+func (x *PeerInfo) GetEd25519Pubkey() []byte {
+	if x != nil {
+		return x.Ed25519Pubkey
+	}
+	return nil
+}
+
+func (x *PeerInfo) GetLastSeen() uint64 {
+	if x != nil {
+		return x.LastSeen
+	}
+	return 0
+}
+
+// PeerExchange carries a list of known peers (msg_type=4).
+type PeerExchange struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Peers         []*PeerInfo            `protobuf:"bytes,1,rep,name=peers,proto3" json:"peers,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PeerExchange) Reset() {
+	*x = PeerExchange{}
+	mi := &file_proto_micelio_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PeerExchange) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PeerExchange) ProtoMessage() {}
+
+func (x *PeerExchange) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_micelio_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PeerExchange.ProtoReflect.Descriptor instead.
+func (*PeerExchange) Descriptor() ([]byte, []int) {
+	return file_proto_micelio_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *PeerExchange) GetPeers() []*PeerInfo {
+	if x != nil {
+		return x.Peers
+	}
+	return nil
+}
+
 var File_proto_micelio_proto protoreflect.FileDescriptor
 
 const file_proto_micelio_proto_rawDesc = "" +
@@ -382,7 +504,15 @@ const file_proto_micelio_proto_rawDesc = "" +
 	"\vChatMessage\x12\x12\n" +
 	"\x04nick\x18\x01 \x01(\tR\x04nick\x12\x12\n" +
 	"\x04text\x18\x02 \x01(\tR\x04text\x12\x1c\n" +
-	"\ttimestamp\x18\x03 \x01(\x04R\ttimestampB\x13Z\x11micelio/pkg/protob\x06proto3"
+	"\ttimestamp\x18\x03 \x01(\x04R\ttimestamp\"\x99\x01\n" +
+	"\bPeerInfo\x12\x17\n" +
+	"\anode_id\x18\x01 \x01(\tR\x06nodeId\x12\x12\n" +
+	"\x04addr\x18\x02 \x01(\tR\x04addr\x12\x1c\n" +
+	"\treachable\x18\x03 \x01(\bR\treachable\x12%\n" +
+	"\x0eed25519_pubkey\x18\x04 \x01(\fR\red25519Pubkey\x12\x1b\n" +
+	"\tlast_seen\x18\x05 \x01(\x04R\blastSeen\"7\n" +
+	"\fPeerExchange\x12'\n" +
+	"\x05peers\x18\x01 \x03(\v2\x11.micelio.PeerInfoR\x05peersB\x13Z\x11micelio/pkg/protob\x06proto3"
 
 var (
 	file_proto_micelio_proto_rawDescOnce sync.Once
@@ -396,19 +526,22 @@ func file_proto_micelio_proto_rawDescGZIP() []byte {
 	return file_proto_micelio_proto_rawDescData
 }
 
-var file_proto_micelio_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_proto_micelio_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
 var file_proto_micelio_proto_goTypes = []any{
 	(*Envelope)(nil),     // 0: micelio.Envelope
 	(*PeerHello)(nil),    // 1: micelio.PeerHello
 	(*PeerHelloAck)(nil), // 2: micelio.PeerHelloAck
 	(*ChatMessage)(nil),  // 3: micelio.ChatMessage
+	(*PeerInfo)(nil),     // 4: micelio.PeerInfo
+	(*PeerExchange)(nil), // 5: micelio.PeerExchange
 }
 var file_proto_micelio_proto_depIdxs = []int32{
-	0, // [0:0] is the sub-list for method output_type
-	0, // [0:0] is the sub-list for method input_type
-	0, // [0:0] is the sub-list for extension type_name
-	0, // [0:0] is the sub-list for extension extendee
-	0, // [0:0] is the sub-list for field type_name
+	4, // 0: micelio.PeerExchange.peers:type_name -> micelio.PeerInfo
+	1, // [1:1] is the sub-list for method output_type
+	1, // [1:1] is the sub-list for method input_type
+	1, // [1:1] is the sub-list for extension type_name
+	1, // [1:1] is the sub-list for extension extendee
+	0, // [0:1] is the sub-list for field type_name
 }
 
 func init() { file_proto_micelio_proto_init() }
@@ -422,7 +555,7 @@ func file_proto_micelio_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_proto_micelio_proto_rawDesc), len(file_proto_micelio_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   4,
+			NumMessages:   6,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/proto/micelio.proto
+++ b/proto/micelio.proto
@@ -43,3 +43,17 @@ message ChatMessage {
     string text      = 2;
     uint64 timestamp = 3;
 }
+
+// PeerInfo describes a known peer for exchange.
+message PeerInfo {
+    string node_id        = 1;
+    string addr           = 2;
+    bool   reachable      = 3;
+    bytes  ed25519_pubkey = 4;
+    uint64 last_seen      = 5;
+}
+
+// PeerExchange carries a list of known peers (msg_type=4).
+message PeerExchange {
+    repeated PeerInfo peers = 1;
+}


### PR DESCRIPTION
## Summary

- **PeerExchange protocol (msg_type=4):** nodes share known reachable peers via signed `PeerExchange` messages, both on connect and periodically (default 30s)
- **Automatic mesh formation:** discovery loop (default 10s) scans the known peers table and dials candidates with random jitter, exponential backoff, and MaxPeers enforcement
- **Persistent peer table:** `knownPeers` stored in bbolt (`peers` bucket), survives restarts, JSON-encoded for debuggability
- **Security:** incoming PeerInfo validated (`node_id == sha256(ed25519_pubkey)`), wildcard addresses suppressed, bootstrap addresses excluded from discovery dials
- **Config additions:** `advertise_addr`, `exchange_interval`, `discovery_interval`, `MaxPeers` (default 15)
- **Early MaxPeers reject:** inbound connections rejected before Noise handshake when at capacity

## New files

| File | Description |
|------|-------------|
| `internal/transport/discovery.go` | PeerRecord, persistence, exchange/discovery loops, merge, dial logic |
| `internal/transport/discovery_test.go` | 3-node mesh, 5-node chain→mesh, MaxPeers enforcement, PeerRecord tests |

## Modified files

| File | Change |
|------|--------|
| `proto/micelio.proto` | Add `PeerInfo` + `PeerExchange` messages |
| `internal/config/config.go` | `Duration` type, `AdvertiseAddr`, `ExchangeInterval`, `DiscoveryInterval` |
| `internal/transport/peer.go` | `MsgTypePeerExchange`, hello metadata, `onPeerExchange` callback |
| `internal/transport/manager.go` | Store, knownPeers, dialing, bootstrapAddrs, advertiseAddr, early MaxPeers |
| `internal/transport/manager_test.go` | `nil` store param, `noDiscovery` intervals for Phase 2 tests |
| `cmd/micelio/main.go` | Pass bbolt store to `NewManager` |
| `docs/*` | Full doc update across all 4 doc files |

## Test plan

- [x] `go test -race ./...` — all pass
- [x] `TestThreeNodeMesh` — 3 nodes (A↔B, C↔B) form full mesh via PeerExchange
- [x] `TestChainToMesh` — 5-node chain A→B→C→D→E converges to full mesh, message from A reaches E
- [x] `TestMaxPeersEnforcement` — center with MaxPeers=1 rejects second spoke
- [x] `TestPeerRecordString` — Stringer implementation, short NodeID safety
- [x] All Phase 2 tests still pass (star, bridge, two-node chat)