### PR TITLE
Phase 4: gossip protocol

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,14 @@ jobs:
       - name: Test with coverage
         run: go test -v -race -timeout 120s -coverprofile=coverage.out -covermode=atomic ./...
 
+      - name: Filter generated code from coverage
+        run: grep -v '.pb.go' coverage.out > coverage-filtered.out
+
       - name: Upload coverage to Coveralls
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          file: coverage.out
+          file: coverage-filtered.out
           format: golang
 
       - name: Cross-compile (linux/arm64)

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ CMD      := ./cmd/micelio
 VERSION  := $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 LDFLAGS  := -s -w -X main.version=$(VERSION)
 
-.PHONY: all build clean test proto linux-amd64 linux-arm64 linux-386 darwin-arm64
+.PHONY: all build clean test cover proto linux-amd64 linux-arm64 linux-386 darwin-arm64
 
 all: build
 
@@ -15,6 +15,12 @@ build:
 
 test:
 	go test ./...
+
+cover:
+	go test ./... -coverprofile=coverage.out
+	@grep -v '.pb.go' coverage.out > coverage-filtered.out
+	@go tool cover -func=coverage-filtered.out | tail -1
+	@rm -f coverage.out coverage-filtered.out
 
 clean:
 	rm -rf bin/

--- a/README.md
+++ b/README.md
@@ -137,9 +137,11 @@ micelio/
 │   ├── partyline/         # Chat hub (channel-based, zero mutexes)
 │   ├── ssh/               # SSH server, terminal sessions
 │   ├── store/             # Store interface + bbolt implementation
+│   ├── gossip/            # Gossip engine (dedup, keyring, rate limiter, forwarding)
 │   └── transport/         # Noise encryption, wire framing, peer management, discovery
-├── pkg/proto/             # Generated protobuf Go code
+├── pkg/proto/             # Generated protobuf Go code + sign/verify helpers
 ├── proto/                 # Protobuf definitions
+├── plugin/builtin/        # Built-in plugins (ping, etc.)
 ├── docs/                  # Protocol documentation (MkDocs)
 ├── Makefile
 └── go.mod
@@ -150,10 +152,13 @@ micelio/
 - [x] **Phase 1** — Standalone node with SSH partyline
 - [x] **Phase 2** — Two nodes, direct connection ([#1](../../issues/1))
 - [x] **Phase 3** — Peer discovery and mesh formation ([#2](../../issues/2))
-- [ ] **Phase 4** — Gossip protocol ([#3](../../issues/3))
+- [x] **Phase 4** — Gossip protocol ([#3](../../issues/3))
 - [ ] **Phase 5** — Distributed state map with LWW + Lamport clock ([#4](../../issues/4))
 - [ ] **Phase 6** — Tagging and desired state ([#5](../../issues/5))
 - [ ] **Phase 7** — Plugin system ([#6](../../issues/6))
+- [ ] **Phase 8** — Access control: allowlist / denylist ([#10](../../issues/10))
+- [ ] **Phase 9** — Web-of-trust ([#11](../../issues/11))
+- [ ] **Phase 10** — Distributed hash table ([#12](../../issues/12))
 
 Each phase produces a working, testable binary. Each phase adds a layer without rewriting the ones below.
 

--- a/internal/gossip/gossip.go
+++ b/internal/gossip/gossip.go
@@ -1,0 +1,229 @@
+package gossip
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/hex"
+	"log"
+	"math/rand/v2"
+	"sync"
+	"time"
+
+	"google.golang.org/protobuf/proto"
+
+	pb "micelio/pkg/proto"
+)
+
+const (
+	DefaultFanout    = 3
+	DefaultMaxHops   = 10
+	DefaultSeenTTL   = 5 * time.Minute
+	DefaultMaxPerSec = 10.0
+	seenCleanup      = 1 * time.Minute
+	limiterCleanup   = 1 * time.Minute
+)
+
+// PeerHandle is a lightweight reference to a connected peer that the engine
+// can send serialized envelopes to.
+type PeerHandle struct {
+	NodeID string
+	Send   func([]byte) bool // returns false if buffer full
+}
+
+// MessageHandler processes a validated gossip message locally.
+type MessageHandler func(senderID string, payload []byte)
+
+// Engine is the gossip protocol engine. It handles deduplication, signature
+// verification via keyring, rate limiting, hop count enforcement, local
+// delivery to registered handlers, and random-subset forwarding.
+type Engine struct {
+	localID string
+
+	Seen    *SeenCache
+	KeyRing *KeyRing
+	Limiter *RateLimiter
+
+	fanout  int
+	maxHops uint32
+
+	// getPeers returns handles to all currently connected peers.
+	getPeers func() []PeerHandle
+
+	handlers map[uint32]MessageHandler
+
+	done     chan struct{}
+	stopOnce sync.Once
+}
+
+// NewEngine creates a gossip engine.
+// localID is the local node's ID (excluded from forwarding targets).
+// getPeers returns the current set of connected peers with send capabilities.
+func NewEngine(localID string, getPeers func() []PeerHandle) *Engine {
+	return &Engine{
+		localID:  localID,
+		Seen:     NewSeenCache(DefaultSeenTTL),
+		KeyRing:  NewKeyRing(),
+		Limiter:  NewRateLimiter(DefaultMaxPerSec),
+		fanout:   DefaultFanout,
+		maxHops:  DefaultMaxHops,
+		getPeers: getPeers,
+		handlers: make(map[uint32]MessageHandler),
+		done:     make(chan struct{}),
+	}
+}
+
+// Start launches background cleanup goroutines.
+func (e *Engine) Start() {
+	go e.Seen.CleanupLoop(e.done, seenCleanup)
+	go e.Limiter.CleanupLoop(e.done, limiterCleanup)
+}
+
+// Stop shuts down the engine's background goroutines. Safe to call multiple times.
+func (e *Engine) Stop() {
+	e.stopOnce.Do(func() { close(e.done) })
+}
+
+// MaxHops returns the default hop count for locally originated messages.
+func (e *Engine) MaxHops() uint32 {
+	return e.maxHops
+}
+
+// RegisterHandler registers a local handler for a message type.
+// Messages with this type will be delivered to the handler after validation.
+// Unknown message types are still forwarded via gossip but not processed locally.
+// Must be called before Start() — not safe for concurrent use with HandleIncoming.
+func (e *Engine) RegisterHandler(msgType uint32, handler MessageHandler) {
+	e.handlers[msgType] = handler
+}
+
+// HandleIncoming processes a gossip message received from a connected peer.
+// It performs deduplication, signature verification, rate limiting, hop count
+// enforcement, local delivery, and forwarding.
+func (e *Engine) HandleIncoming(fromPeerID string, env *pb.Envelope) {
+	// 0. Reject malformed envelopes missing required identifiers.
+	if env.MessageId == "" || env.SenderId == "" {
+		return
+	}
+
+	// 1. Quick dedup (read-only; does NOT mark the ID as seen)
+	if e.Seen.Has(env.MessageId) {
+		return
+	}
+
+	// 2. Lookup sender in keyring; auto-learn from sender_pubkey if unknown
+	entry, known := e.KeyRing.Lookup(env.SenderId)
+	if !known {
+		// Try to learn the key from the envelope's sender_pubkey field.
+		// Verify: len must be 32, and sha256(pubkey) must match sender_id.
+		if len(env.SenderPubkey) == ed25519.PublicKeySize {
+			hash := sha256.Sum256(env.SenderPubkey)
+			if hex.EncodeToString(hash[:]) == env.SenderId {
+				e.KeyRing.Add(env.SenderId, env.SenderPubkey, TrustGossipLearned)
+				entry, known = e.KeyRing.Lookup(env.SenderId)
+			}
+		}
+		if !known {
+			log.Printf("gossip: dropping message %s from unknown sender %s",
+				env.MessageId, formatShort(env.SenderId))
+			return
+		}
+	}
+
+	// 3. Verify signature
+	if !pb.VerifyEnvelope(env, entry.PubKey) {
+		log.Printf("gossip: invalid signature on message %s from %s",
+			env.MessageId, formatShort(env.SenderId))
+		return
+	}
+
+	// 4. Rate limit (before marking seen, so rate-limited messages can be
+	// retried when the sender's budget replenishes).
+	if !e.Limiter.Allow(env.SenderId) {
+		log.Printf("gossip: rate limit exceeded for sender %s",
+			formatShort(env.SenderId))
+		return
+	}
+
+	// 5. Atomic test-and-set AFTER verification and rate limiting succeed.
+	// This ensures dropped messages (unknown sender, bad signature, rate-limited)
+	// don't pollute the seen cache — they can be retried when conditions change.
+	if e.Seen.Check(env.MessageId) {
+		return
+	}
+
+	// 6. Deliver to local handler (if registered for this msg_type)
+	if handler, ok := e.handlers[env.MsgType]; ok {
+		handler(env.SenderId, env.Payload)
+	}
+
+	// 7. Forward if hop count allows
+	if env.HopCount <= 1 {
+		return
+	}
+
+	// Decrement hop count and re-serialize
+	env.HopCount--
+	raw, err := proto.Marshal(env)
+	if err != nil {
+		log.Printf("gossip: marshal for forward: %v", err)
+		return
+	}
+
+	e.forwardTo(raw, fromPeerID)
+}
+
+// Broadcast sends a locally originated, already-signed envelope to all
+// connected peers. The caller is responsible for setting HopCount, signing
+// the envelope, etc.
+func (e *Engine) Broadcast(env *pb.Envelope) {
+	// Mark as seen so we don't re-process if it comes back
+	e.Seen.Check(env.MessageId)
+
+	raw, err := proto.Marshal(env)
+	if err != nil {
+		log.Printf("gossip: marshal broadcast: %v", err)
+		return
+	}
+
+	// Originator sends to ALL connected peers
+	peers := e.getPeers()
+	for _, p := range peers {
+		p.Send(raw)
+	}
+}
+
+// forwardTo sends serialized envelope bytes to a random subset of connected
+// peers, excluding the peer that forwarded the message to us.
+func (e *Engine) forwardTo(raw []byte, excludePeerID string) {
+	peers := e.getPeers()
+
+	var candidates []PeerHandle
+	for _, p := range peers {
+		if p.NodeID != excludePeerID {
+			candidates = append(candidates, p)
+		}
+	}
+
+	if len(candidates) == 0 {
+		return
+	}
+
+	// Random subset selection (fanout)
+	if len(candidates) > e.fanout {
+		rand.Shuffle(len(candidates), func(i, j int) {
+			candidates[i], candidates[j] = candidates[j], candidates[i]
+		})
+		candidates = candidates[:e.fanout]
+	}
+
+	for _, p := range candidates {
+		p.Send(raw)
+	}
+}
+
+func formatShort(id string) string {
+	if len(id) > 12 {
+		return id[:12]
+	}
+	return id
+}

--- a/internal/gossip/gossip_test.go
+++ b/internal/gossip/gossip_test.go
@@ -1,0 +1,704 @@
+package gossip
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"google.golang.org/protobuf/proto"
+
+	pb "micelio/pkg/proto"
+)
+
+type testIdentity struct {
+	nodeID string
+	pub    ed25519.PublicKey
+	priv   ed25519.PrivateKey
+}
+
+func newTestIdentity(t *testing.T) testIdentity {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	return testIdentity{
+		nodeID: "test-node-" + uuid.New().String()[:8],
+		pub:    pub,
+		priv:   priv,
+	}
+}
+
+func makeSignedEnvelope(t *testing.T, id testIdentity, msgType uint32, payload []byte, hopCount uint32) *pb.Envelope {
+	t.Helper()
+	env := &pb.Envelope{
+		MessageId: uuid.New().String(),
+		SenderId:  id.nodeID,
+		MsgType:   msgType,
+		HopCount:  hopCount,
+		Payload:   payload,
+	}
+	pb.SignEnvelope(env, id.priv)
+	return env
+}
+
+func TestEngineDedup(t *testing.T) {
+	local := newTestIdentity(t)
+	sender := newTestIdentity(t)
+
+	var delivered int
+	var mu sync.Mutex
+
+	engine := NewEngine(local.nodeID, func() []PeerHandle { return nil })
+	engine.KeyRing.Add(sender.nodeID, sender.pub, TrustDirectlyVerified)
+	engine.RegisterHandler(3, func(senderID string, payload []byte) {
+		mu.Lock()
+		delivered++
+		mu.Unlock()
+	})
+
+	env := makeSignedEnvelope(t, sender, 3, []byte("hello"), 5)
+
+	// First delivery
+	engine.HandleIncoming("peer-a", env)
+
+	// Duplicate delivery (same message ID)
+	engine.HandleIncoming("peer-b", env)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if delivered != 1 {
+		t.Fatalf("expected 1 delivery, got %d", delivered)
+	}
+}
+
+func TestEngineUnknownSender(t *testing.T) {
+	local := newTestIdentity(t)
+	sender := newTestIdentity(t)
+
+	var delivered int
+
+	engine := NewEngine(local.nodeID, func() []PeerHandle { return nil })
+	// NOT adding sender to keyring
+	engine.RegisterHandler(3, func(senderID string, payload []byte) {
+		delivered++
+	})
+
+	env := makeSignedEnvelope(t, sender, 3, []byte("hello"), 5)
+	engine.HandleIncoming("peer-a", env)
+
+	if delivered != 0 {
+		t.Fatal("expected no delivery for unknown sender")
+	}
+}
+
+func TestEngineAutoLearnKey(t *testing.T) {
+	local := newTestIdentity(t)
+
+	// Create a sender with a real nodeID = sha256(pubkey)
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hash := sha256.Sum256(pub)
+	realNodeID := hex.EncodeToString(hash[:])
+
+	var delivered int
+	engine := NewEngine(local.nodeID, func() []PeerHandle { return nil })
+	// NOT adding sender to keyring — should auto-learn from sender_pubkey
+	engine.RegisterHandler(3, func(senderID string, payload []byte) {
+		delivered++
+	})
+
+	env := &pb.Envelope{
+		MessageId:    uuid.New().String(),
+		SenderId:     realNodeID,
+		MsgType:      3,
+		HopCount:     5,
+		Payload:      []byte("hello"),
+		SenderPubkey: pub,
+	}
+	pb.SignEnvelope(env, priv)
+
+	engine.HandleIncoming("peer-a", env)
+
+	if delivered != 1 {
+		t.Fatalf("expected 1 delivery via auto-learn, got %d", delivered)
+	}
+
+	// Verify the key was added to the keyring
+	entry, ok := engine.KeyRing.Lookup(realNodeID)
+	if !ok {
+		t.Fatal("expected key to be auto-learned into keyring")
+	}
+	if entry.TrustLevel != TrustGossipLearned {
+		t.Fatalf("expected TrustGossipLearned, got %d", entry.TrustLevel)
+	}
+}
+
+func TestEngineAutoLearnKeyBadHash(t *testing.T) {
+	local := newTestIdentity(t)
+
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var delivered int
+	engine := NewEngine(local.nodeID, func() []PeerHandle { return nil })
+	engine.RegisterHandler(3, func(senderID string, payload []byte) {
+		delivered++
+	})
+
+	// sender_id does NOT match sha256(sender_pubkey)
+	env := &pb.Envelope{
+		MessageId:    uuid.New().String(),
+		SenderId:     "fake-node-id",
+		MsgType:      3,
+		HopCount:     5,
+		Payload:      []byte("hello"),
+		SenderPubkey: pub,
+	}
+	pb.SignEnvelope(env, priv)
+
+	engine.HandleIncoming("peer-a", env)
+
+	if delivered != 0 {
+		t.Fatal("expected no delivery when sender_pubkey hash doesn't match sender_id")
+	}
+}
+
+func TestEngineInvalidSignature(t *testing.T) {
+	local := newTestIdentity(t)
+	sender := newTestIdentity(t)
+	impostor := newTestIdentity(t)
+
+	var delivered int
+
+	engine := NewEngine(local.nodeID, func() []PeerHandle { return nil })
+	// Add sender's key, but the message is signed with impostor's key
+	engine.KeyRing.Add(sender.nodeID, sender.pub, TrustDirectlyVerified)
+	engine.RegisterHandler(3, func(senderID string, payload []byte) {
+		delivered++
+	})
+
+	env := &pb.Envelope{
+		MessageId: uuid.New().String(),
+		SenderId:  sender.nodeID, // claims to be sender
+		MsgType:   3,
+		HopCount:  5,
+		Payload:   []byte("hello"),
+	}
+	pb.SignEnvelope(env, impostor.priv) // but signed by impostor
+
+	engine.HandleIncoming("peer-a", env)
+
+	if delivered != 0 {
+		t.Fatal("expected no delivery for invalid signature")
+	}
+}
+
+func TestEngineHopCountZero(t *testing.T) {
+	local := newTestIdentity(t)
+	sender := newTestIdentity(t)
+
+	var forwarded []string
+	var mu sync.Mutex
+
+	engine := NewEngine(local.nodeID, func() []PeerHandle {
+		return []PeerHandle{{
+			NodeID: "peer-b",
+			Send: func(data []byte) bool {
+				mu.Lock()
+				forwarded = append(forwarded, "peer-b")
+				mu.Unlock()
+				return true
+			},
+		}}
+	})
+	engine.KeyRing.Add(sender.nodeID, sender.pub, TrustDirectlyVerified)
+
+	var delivered int
+	engine.RegisterHandler(3, func(senderID string, payload []byte) {
+		delivered++
+	})
+
+	// hop_count=1: should deliver locally but NOT forward
+	env := makeSignedEnvelope(t, sender, 3, []byte("hello"), 1)
+	engine.HandleIncoming("peer-a", env)
+
+	if delivered != 1 {
+		t.Fatalf("expected 1 delivery, got %d", delivered)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(forwarded) != 0 {
+		t.Fatalf("expected no forwarding with hop_count=1, got %d", len(forwarded))
+	}
+}
+
+func TestEngineForwarding(t *testing.T) {
+	local := newTestIdentity(t)
+	sender := newTestIdentity(t)
+
+	var forwarded []string
+	var mu sync.Mutex
+
+	engine := NewEngine(local.nodeID, func() []PeerHandle {
+		return []PeerHandle{
+			{NodeID: "peer-a", Send: func(data []byte) bool {
+				mu.Lock()
+				forwarded = append(forwarded, "peer-a")
+				mu.Unlock()
+				return true
+			}},
+			{NodeID: "peer-b", Send: func(data []byte) bool {
+				mu.Lock()
+				forwarded = append(forwarded, "peer-b")
+				mu.Unlock()
+				return true
+			}},
+			{NodeID: "peer-c", Send: func(data []byte) bool {
+				mu.Lock()
+				forwarded = append(forwarded, "peer-c")
+				mu.Unlock()
+				return true
+			}},
+		}
+	})
+	engine.KeyRing.Add(sender.nodeID, sender.pub, TrustDirectlyVerified)
+	engine.RegisterHandler(3, func(senderID string, payload []byte) {})
+
+	env := makeSignedEnvelope(t, sender, 3, []byte("hello"), 5)
+	engine.HandleIncoming("peer-a", env) // received from peer-a
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// Should forward to peer-b and/or peer-c, but NOT peer-a (the sender)
+	for _, id := range forwarded {
+		if id == "peer-a" {
+			t.Fatal("should not forward back to sender")
+		}
+	}
+	if len(forwarded) == 0 {
+		t.Fatal("expected at least one forward")
+	}
+}
+
+func TestEngineForwardDecrementHopCount(t *testing.T) {
+	local := newTestIdentity(t)
+	sender := newTestIdentity(t)
+
+	var receivedData []byte
+	var mu sync.Mutex
+
+	engine := NewEngine(local.nodeID, func() []PeerHandle {
+		return []PeerHandle{
+			{NodeID: "peer-b", Send: func(data []byte) bool {
+				mu.Lock()
+				receivedData = data
+				mu.Unlock()
+				return true
+			}},
+		}
+	})
+	engine.KeyRing.Add(sender.nodeID, sender.pub, TrustDirectlyVerified)
+	engine.RegisterHandler(3, func(senderID string, payload []byte) {})
+
+	env := makeSignedEnvelope(t, sender, 3, []byte("hello"), 5)
+	engine.HandleIncoming("peer-a", env)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if receivedData == nil {
+		t.Fatal("expected forwarded data")
+	}
+
+	var forwarded pb.Envelope
+	if err := proto.Unmarshal(receivedData, &forwarded); err != nil {
+		t.Fatalf("unmarshal forwarded: %v", err)
+	}
+	if forwarded.HopCount != 4 {
+		t.Fatalf("expected hop_count=4, got %d", forwarded.HopCount)
+	}
+}
+
+func TestEngineBroadcast(t *testing.T) {
+	local := newTestIdentity(t)
+
+	var sentTo []string
+	var mu sync.Mutex
+
+	engine := NewEngine(local.nodeID, func() []PeerHandle {
+		return []PeerHandle{
+			{NodeID: "peer-a", Send: func(data []byte) bool {
+				mu.Lock()
+				sentTo = append(sentTo, "peer-a")
+				mu.Unlock()
+				return true
+			}},
+			{NodeID: "peer-b", Send: func(data []byte) bool {
+				mu.Lock()
+				sentTo = append(sentTo, "peer-b")
+				mu.Unlock()
+				return true
+			}},
+		}
+	})
+
+	env := makeSignedEnvelope(t, local, 3, []byte("hello"), 10)
+	engine.Broadcast(env)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// Broadcast sends to ALL peers
+	if len(sentTo) != 2 {
+		t.Fatalf("expected 2 sends, got %d", len(sentTo))
+	}
+}
+
+func TestEngineBroadcastMarksSeen(t *testing.T) {
+	local := newTestIdentity(t)
+
+	engine := NewEngine(local.nodeID, func() []PeerHandle { return nil })
+
+	env := makeSignedEnvelope(t, local, 3, []byte("hello"), 10)
+	engine.Broadcast(env)
+
+	// The message should now be seen
+	if !engine.Seen.Check(env.MessageId) {
+		t.Fatal("expected broadcast message to be marked as seen")
+	}
+}
+
+func TestEngineUnknownMsgType(t *testing.T) {
+	local := newTestIdentity(t)
+	sender := newTestIdentity(t)
+
+	var forwarded int
+	var mu sync.Mutex
+
+	engine := NewEngine(local.nodeID, func() []PeerHandle {
+		return []PeerHandle{
+			{NodeID: "peer-b", Send: func(data []byte) bool {
+				mu.Lock()
+				forwarded++
+				mu.Unlock()
+				return true
+			}},
+		}
+	})
+	engine.KeyRing.Add(sender.nodeID, sender.pub, TrustDirectlyVerified)
+	// No handler registered for msg_type=999
+
+	env := makeSignedEnvelope(t, sender, 999, []byte("plugin-data"), 5)
+	engine.HandleIncoming("peer-a", env)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// Unknown types should still be forwarded
+	if forwarded != 1 {
+		t.Fatalf("expected 1 forward for unknown msg_type, got %d", forwarded)
+	}
+}
+
+func TestEngineRateLimiting(t *testing.T) {
+	local := newTestIdentity(t)
+	sender := newTestIdentity(t)
+
+	engine := NewEngine(local.nodeID, func() []PeerHandle { return nil })
+	engine.KeyRing.Add(sender.nodeID, sender.pub, TrustDirectlyVerified)
+	// Set very low rate limit
+	engine.Limiter = NewRateLimiter(1.0) // 1/s, burst=2
+
+	var delivered int
+	engine.RegisterHandler(3, func(senderID string, payload []byte) {
+		delivered++
+	})
+
+	// Send 5 messages — only first 2 (burst) should be delivered
+	for i := 0; i < 5; i++ {
+		env := makeSignedEnvelope(t, sender, 3, []byte("msg"), 5)
+		engine.HandleIncoming("peer-a", env)
+	}
+
+	if delivered > 2 {
+		t.Fatalf("expected at most 2 deliveries (burst), got %d", delivered)
+	}
+	if delivered == 0 {
+		t.Fatal("expected at least 1 delivery")
+	}
+}
+
+func TestEngineFanoutLimit(t *testing.T) {
+	local := newTestIdentity(t)
+	sender := newTestIdentity(t)
+
+	var forwarded int
+	var mu sync.Mutex
+
+	// Create 10 peers
+	peers := make([]PeerHandle, 10)
+	for i := range peers {
+		peers[i] = PeerHandle{
+			NodeID: "peer-" + string(rune('A'+i)),
+			Send: func(data []byte) bool {
+				mu.Lock()
+				forwarded++
+				mu.Unlock()
+				return true
+			},
+		}
+	}
+
+	engine := NewEngine(local.nodeID, func() []PeerHandle { return peers })
+	engine.KeyRing.Add(sender.nodeID, sender.pub, TrustDirectlyVerified)
+	engine.RegisterHandler(3, func(senderID string, payload []byte) {})
+
+	env := makeSignedEnvelope(t, sender, 3, []byte("hello"), 5)
+	engine.HandleIncoming("external-peer", env)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// Fanout is 3 — should forward to at most 3 peers
+	if forwarded > DefaultFanout {
+		t.Fatalf("expected at most %d forwards, got %d", DefaultFanout, forwarded)
+	}
+	if forwarded == 0 {
+		t.Fatal("expected at least 1 forward")
+	}
+}
+
+func TestEngineStartStop(t *testing.T) {
+	local := newTestIdentity(t)
+	engine := NewEngine(local.nodeID, func() []PeerHandle { return nil })
+
+	engine.Start()
+	time.Sleep(50 * time.Millisecond)
+	engine.Stop()
+	// Should not panic or deadlock
+}
+
+func TestEngineAutoLearnKeyBadSignature(t *testing.T) {
+	local := newTestIdentity(t)
+	impostor := newTestIdentity(t)
+
+	// Create a real nodeID from a different key pair
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hash := sha256.Sum256(pub)
+	realNodeID := hex.EncodeToString(hash[:])
+
+	var delivered int
+	engine := NewEngine(local.nodeID, func() []PeerHandle { return nil })
+	engine.RegisterHandler(3, func(senderID string, payload []byte) {
+		delivered++
+	})
+
+	// sender_pubkey hash matches sender_id, but envelope is signed by impostor
+	env := &pb.Envelope{
+		MessageId:    uuid.New().String(),
+		SenderId:     realNodeID,
+		MsgType:      3,
+		HopCount:     5,
+		Payload:      []byte("hello"),
+		SenderPubkey: pub,
+	}
+	pb.SignEnvelope(env, impostor.priv) // wrong key!
+
+	engine.HandleIncoming("peer-a", env)
+
+	if delivered != 0 {
+		t.Fatal("expected no delivery when signature doesn't match sender_pubkey")
+	}
+}
+
+func TestEngineHopCountZeroNotForwarded(t *testing.T) {
+	local := newTestIdentity(t)
+	sender := newTestIdentity(t)
+
+	var delivered int
+	var forwarded int
+
+	engine := NewEngine(local.nodeID, func() []PeerHandle {
+		return []PeerHandle{{
+			NodeID: "peer-b",
+			Send:   func(data []byte) bool { forwarded++; return true },
+		}}
+	})
+	engine.KeyRing.Add(sender.nodeID, sender.pub, TrustDirectlyVerified)
+	engine.RegisterHandler(3, func(senderID string, payload []byte) {
+		delivered++
+	})
+
+	// hop_count=0: should still deliver locally but not forward
+	env := makeSignedEnvelope(t, sender, 3, []byte("hello"), 0)
+	engine.HandleIncoming("peer-a", env)
+
+	if delivered != 1 {
+		t.Fatalf("expected 1 delivery with hop_count=0, got %d", delivered)
+	}
+	if forwarded != 0 {
+		t.Fatalf("expected no forwarding with hop_count=0, got %d", forwarded)
+	}
+}
+
+func TestEngineDroppedMessageNotMarkedSeen(t *testing.T) {
+	local := newTestIdentity(t)
+
+	// Create a sender with a real nodeID = sha256(pubkey)
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hash := sha256.Sum256(pub)
+	realNodeID := hex.EncodeToString(hash[:])
+
+	var delivered int
+	engine := NewEngine(local.nodeID, func() []PeerHandle { return nil })
+	engine.RegisterHandler(3, func(senderID string, payload []byte) {
+		delivered++
+	})
+
+	env := &pb.Envelope{
+		MessageId:    uuid.New().String(),
+		SenderId:     realNodeID,
+		MsgType:      3,
+		HopCount:     5,
+		Payload:      []byte("hello"),
+		SenderPubkey: pub,
+	}
+	pb.SignEnvelope(env, priv)
+
+	// First attempt: sender unknown (no sender_pubkey in this copy)
+	envNoKey := &pb.Envelope{
+		MessageId: env.MessageId,
+		SenderId:  realNodeID,
+		MsgType:   3,
+		HopCount:  5,
+		Payload:   []byte("hello"),
+		Signature: env.Signature,
+		// SenderPubkey intentionally omitted
+	}
+	engine.HandleIncoming("peer-a", envNoKey)
+	if delivered != 0 {
+		t.Fatal("expected no delivery for unknown sender without sender_pubkey")
+	}
+
+	// The message ID should NOT be in the seen cache
+	if engine.Seen.Has(env.MessageId) {
+		t.Fatal("dropped message should not be marked as seen")
+	}
+
+	// Second attempt: same message with sender_pubkey → should auto-learn and deliver
+	engine.HandleIncoming("peer-a", env)
+	if delivered != 1 {
+		t.Fatalf("expected 1 delivery after retry with sender_pubkey, got %d", delivered)
+	}
+}
+
+func TestEngineMaxHops(t *testing.T) {
+	local := newTestIdentity(t)
+	engine := NewEngine(local.nodeID, func() []PeerHandle { return nil })
+
+	if got := engine.MaxHops(); got != DefaultMaxHops {
+		t.Fatalf("MaxHops() = %d, want %d", got, DefaultMaxHops)
+	}
+}
+
+func TestEngineBroadcastNoPeers(t *testing.T) {
+	local := newTestIdentity(t)
+	engine := NewEngine(local.nodeID, func() []PeerHandle { return nil })
+
+	env := makeSignedEnvelope(t, local, 3, []byte("hello"), 10)
+	// Should not panic with zero peers
+	engine.Broadcast(env)
+
+	// Message should still be marked as seen
+	if !engine.Seen.Has(env.MessageId) {
+		t.Fatal("broadcast with no peers should still mark message as seen")
+	}
+}
+
+func TestEngineForwardNoCandidates(t *testing.T) {
+	local := newTestIdentity(t)
+	sender := newTestIdentity(t)
+
+	var forwarded int
+	// Only peer is the one who sent us the message — no forwarding candidates
+	engine := NewEngine(local.nodeID, func() []PeerHandle {
+		return []PeerHandle{
+			{NodeID: "peer-a", Send: func(data []byte) bool { forwarded++; return true }},
+		}
+	})
+	engine.KeyRing.Add(sender.nodeID, sender.pub, TrustDirectlyVerified)
+	engine.RegisterHandler(3, func(senderID string, payload []byte) {})
+
+	env := makeSignedEnvelope(t, sender, 3, []byte("hello"), 5)
+	engine.HandleIncoming("peer-a", env) // from peer-a, the only peer
+
+	if forwarded != 0 {
+		t.Fatalf("expected 0 forwards when only peer is sender, got %d", forwarded)
+	}
+}
+
+func TestEngineAutoLearnKeyBadPubkeySize(t *testing.T) {
+	local := newTestIdentity(t)
+
+	var delivered int
+	engine := NewEngine(local.nodeID, func() []PeerHandle { return nil })
+	engine.RegisterHandler(3, func(senderID string, payload []byte) {
+		delivered++
+	})
+
+	_, priv, _ := ed25519.GenerateKey(rand.Reader)
+
+	// sender_pubkey with wrong length (not 32 bytes)
+	env := &pb.Envelope{
+		MessageId:    uuid.New().String(),
+		SenderId:     "unknown-sender",
+		MsgType:      3,
+		HopCount:     5,
+		Payload:      []byte("hello"),
+		SenderPubkey: []byte("too-short"),
+	}
+	pb.SignEnvelope(env, priv)
+	engine.HandleIncoming("peer-a", env)
+
+	if delivered != 0 {
+		t.Fatal("expected no delivery with bad sender_pubkey size")
+	}
+}
+
+func TestSeenCacheHasReadOnly(t *testing.T) {
+	cache := NewSeenCache(time.Minute)
+
+	// Has on unknown ID returns false and does NOT add it
+	if cache.Has("msg-1") {
+		t.Fatal("expected Has to return false for unknown ID")
+	}
+	if cache.Len() != 0 {
+		t.Fatal("Has should not add entries to the cache")
+	}
+
+	// Check adds it
+	if cache.Check("msg-1") {
+		t.Fatal("expected Check to return false on first call")
+	}
+	if !cache.Has("msg-1") {
+		t.Fatal("expected Has to return true after Check")
+	}
+}

--- a/internal/gossip/keyring.go
+++ b/internal/gossip/keyring.go
@@ -1,0 +1,76 @@
+package gossip
+
+import (
+	"crypto/ed25519"
+	"sync"
+)
+
+// TrustLevel indicates how a peer's public key was learned.
+type TrustLevel int
+
+const (
+	// TrustDirectlyVerified means the key was learned via a direct Noise
+	// handshake — the strongest level of trust.
+	TrustDirectlyVerified TrustLevel = iota
+	// TrustGossipLearned means the key was learned via gossip, such as
+	// peer exchange or auto-learning from the sender_pubkey envelope field.
+	// Not independently verified, but usable for signature checks.
+	TrustGossipLearned
+)
+
+// KeyEntry holds a peer's public key and how it was learned.
+type KeyEntry struct {
+	PubKey     ed25519.PublicKey
+	TrustLevel TrustLevel
+}
+
+// KeyRing is a thread-safe map of nodeID → KeyEntry.
+type KeyRing struct {
+	mu   sync.RWMutex
+	keys map[string]KeyEntry
+}
+
+// NewKeyRing creates an empty keyring.
+func NewKeyRing() *KeyRing {
+	return &KeyRing{
+		keys: make(map[string]KeyEntry),
+	}
+}
+
+// Add inserts or upgrades a key in the keyring.
+// A directly-verified key is never downgraded by a gossip-learned key.
+// A gossip-learned key can be upgraded to directly-verified.
+func (kr *KeyRing) Add(nodeID string, pubKey ed25519.PublicKey, trust TrustLevel) {
+	kr.mu.Lock()
+	defer kr.mu.Unlock()
+	existing, ok := kr.keys[nodeID]
+	if ok && trust >= existing.TrustLevel {
+		// Don't downgrade: existing is at same or stronger trust.
+		return
+	}
+	copiedKey := make(ed25519.PublicKey, len(pubKey))
+	copy(copiedKey, pubKey)
+	kr.keys[nodeID] = KeyEntry{PubKey: copiedKey, TrustLevel: trust}
+}
+
+// Lookup returns the key entry for a node, or false if unknown.
+func (kr *KeyRing) Lookup(nodeID string) (KeyEntry, bool) {
+	kr.mu.RLock()
+	defer kr.mu.RUnlock()
+	entry, ok := kr.keys[nodeID]
+	return entry, ok
+}
+
+// Remove deletes a node from the keyring.
+func (kr *KeyRing) Remove(nodeID string) {
+	kr.mu.Lock()
+	defer kr.mu.Unlock()
+	delete(kr.keys, nodeID)
+}
+
+// Len returns the number of entries in the keyring.
+func (kr *KeyRing) Len() int {
+	kr.mu.RLock()
+	defer kr.mu.RUnlock()
+	return len(kr.keys)
+}

--- a/internal/gossip/keyring_test.go
+++ b/internal/gossip/keyring_test.go
@@ -1,0 +1,116 @@
+package gossip
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"testing"
+)
+
+func generateKey(t *testing.T) ed25519.PublicKey {
+	t.Helper()
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	return pub
+}
+
+func TestKeyRingAddAndLookup(t *testing.T) {
+	kr := NewKeyRing()
+	pub := generateKey(t)
+
+	kr.Add("node-a", pub, TrustDirectlyVerified)
+
+	entry, ok := kr.Lookup("node-a")
+	if !ok {
+		t.Fatal("expected to find node-a")
+	}
+	if entry.TrustLevel != TrustDirectlyVerified {
+		t.Fatalf("expected TrustDirectlyVerified, got %d", entry.TrustLevel)
+	}
+	if !entry.PubKey.Equal(pub) {
+		t.Fatal("pubkey mismatch")
+	}
+}
+
+func TestKeyRingUnknownNode(t *testing.T) {
+	kr := NewKeyRing()
+	_, ok := kr.Lookup("unknown")
+	if ok {
+		t.Fatal("expected not found for unknown node")
+	}
+}
+
+func TestKeyRingNoDowngrade(t *testing.T) {
+	kr := NewKeyRing()
+	pub := generateKey(t)
+	pub2 := generateKey(t)
+
+	kr.Add("node-a", pub, TrustDirectlyVerified)
+	// Try to downgrade to gossip-learned with a different key
+	kr.Add("node-a", pub2, TrustGossipLearned)
+
+	entry, _ := kr.Lookup("node-a")
+	if entry.TrustLevel != TrustDirectlyVerified {
+		t.Fatal("trust level was downgraded")
+	}
+	if !entry.PubKey.Equal(pub) {
+		t.Fatal("pubkey was changed by weaker trust")
+	}
+}
+
+func TestKeyRingUpgrade(t *testing.T) {
+	kr := NewKeyRing()
+	pub := generateKey(t)
+	pub2 := generateKey(t)
+
+	kr.Add("node-a", pub, TrustGossipLearned)
+	kr.Add("node-a", pub2, TrustDirectlyVerified)
+
+	entry, _ := kr.Lookup("node-a")
+	if entry.TrustLevel != TrustDirectlyVerified {
+		t.Fatal("trust level was not upgraded")
+	}
+	if !entry.PubKey.Equal(pub2) {
+		t.Fatal("pubkey was not updated on upgrade")
+	}
+}
+
+func TestKeyRingRemove(t *testing.T) {
+	kr := NewKeyRing()
+	kr.Add("node-a", generateKey(t), TrustDirectlyVerified)
+
+	kr.Remove("node-a")
+
+	_, ok := kr.Lookup("node-a")
+	if ok {
+		t.Fatal("expected node-a to be removed")
+	}
+}
+
+func TestKeyRingLen(t *testing.T) {
+	kr := NewKeyRing()
+	if kr.Len() != 0 {
+		t.Fatalf("expected 0, got %d", kr.Len())
+	}
+	kr.Add("a", generateKey(t), TrustDirectlyVerified)
+	kr.Add("b", generateKey(t), TrustGossipLearned)
+	if kr.Len() != 2 {
+		t.Fatalf("expected 2, got %d", kr.Len())
+	}
+}
+
+func TestKeyRingSameLevel(t *testing.T) {
+	kr := NewKeyRing()
+	pub := generateKey(t)
+	pub2 := generateKey(t)
+
+	kr.Add("node-a", pub, TrustGossipLearned)
+	// Same trust level — should NOT overwrite (>= check)
+	kr.Add("node-a", pub2, TrustGossipLearned)
+
+	entry, _ := kr.Lookup("node-a")
+	if !entry.PubKey.Equal(pub) {
+		t.Fatal("pubkey was overwritten at same trust level")
+	}
+}

--- a/internal/gossip/ratelimit.go
+++ b/internal/gossip/ratelimit.go
@@ -1,0 +1,84 @@
+package gossip
+
+import (
+	"sync"
+	"time"
+)
+
+type senderState struct {
+	tokens    float64
+	lastCheck time.Time
+}
+
+// RateLimiter enforces per-sender message rate limits using a token bucket.
+type RateLimiter struct {
+	mu        sync.Mutex
+	senders   map[string]*senderState
+	maxPerSec float64
+	burst     float64 // max tokens (2× maxPerSec)
+}
+
+// NewRateLimiter creates a rate limiter allowing maxPerSec messages per sender.
+func NewRateLimiter(maxPerSec float64) *RateLimiter {
+	return &RateLimiter{
+		senders:   make(map[string]*senderState),
+		maxPerSec: maxPerSec,
+		burst:     maxPerSec * 2,
+	}
+}
+
+// Allow returns true if the sender is within the rate limit.
+// Each call consumes one token.
+func (r *RateLimiter) Allow(senderID string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	now := time.Now()
+	state, ok := r.senders[senderID]
+	if !ok {
+		r.senders[senderID] = &senderState{
+			tokens:    r.burst - 1,
+			lastCheck: now,
+		}
+		return true
+	}
+
+	// Refill tokens based on elapsed time
+	elapsed := now.Sub(state.lastCheck).Seconds()
+	state.tokens += elapsed * r.maxPerSec
+	if state.tokens > r.burst {
+		state.tokens = r.burst
+	}
+	state.lastCheck = now
+
+	if state.tokens >= 1 {
+		state.tokens--
+		return true
+	}
+	return false
+}
+
+// CleanupLoop periodically removes stale sender entries until done is closed.
+func (r *RateLimiter) CleanupLoop(done <-chan struct{}, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			r.cleanup()
+		case <-done:
+			return
+		}
+	}
+}
+
+func (r *RateLimiter) cleanup() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	cutoff := time.Now().Add(-5 * time.Minute)
+	for id, state := range r.senders {
+		if state.lastCheck.Before(cutoff) {
+			delete(r.senders, id)
+		}
+	}
+}

--- a/internal/gossip/ratelimit_test.go
+++ b/internal/gossip/ratelimit_test.go
@@ -1,0 +1,76 @@
+package gossip
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRateLimiterAllow(t *testing.T) {
+	rl := NewRateLimiter(5.0) // 5 per second, burst=10
+
+	// First 10 calls should all be allowed (burst)
+	for i := 0; i < 10; i++ {
+		if !rl.Allow("sender-a") {
+			t.Fatalf("call %d should be allowed", i)
+		}
+	}
+
+	// 11th call should be rejected (burst exhausted)
+	if rl.Allow("sender-a") {
+		t.Fatal("expected rate limit to reject")
+	}
+}
+
+func TestRateLimiterRefill(t *testing.T) {
+	rl := NewRateLimiter(100.0) // 100 per second, burst=200
+
+	// Exhaust burst
+	for i := 0; i < 200; i++ {
+		rl.Allow("sender-a")
+	}
+	if rl.Allow("sender-a") {
+		t.Fatal("expected exhausted")
+	}
+
+	// Wait for refill
+	time.Sleep(50 * time.Millisecond) // ~5 tokens at 100/s
+	if !rl.Allow("sender-a") {
+		t.Fatal("expected allowed after refill")
+	}
+}
+
+func TestRateLimiterIndependentSenders(t *testing.T) {
+	rl := NewRateLimiter(5.0) // burst=10
+
+	// Exhaust sender-a
+	for i := 0; i < 10; i++ {
+		rl.Allow("sender-a")
+	}
+	if rl.Allow("sender-a") {
+		t.Fatal("sender-a should be exhausted")
+	}
+
+	// sender-b should still be allowed
+	if !rl.Allow("sender-b") {
+		t.Fatal("sender-b should be allowed")
+	}
+}
+
+func TestRateLimiterCleanup(t *testing.T) {
+	rl := NewRateLimiter(5.0)
+	rl.Allow("sender-a")
+
+	// Force the lastCheck to be old for cleanup
+	rl.mu.Lock()
+	rl.senders["sender-a"].lastCheck = time.Now().Add(-10 * time.Minute)
+	rl.mu.Unlock()
+
+	rl.cleanup()
+
+	rl.mu.Lock()
+	_, exists := rl.senders["sender-a"]
+	rl.mu.Unlock()
+	if exists {
+		t.Fatal("expected sender-a to be cleaned up")
+	}
+}

--- a/internal/gossip/seen.go
+++ b/internal/gossip/seen.go
@@ -1,0 +1,75 @@
+package gossip
+
+import (
+	"sync"
+	"time"
+)
+
+// SeenCache tracks recently seen message IDs for deduplication.
+// Thread-safe. Entries expire after a configurable TTL.
+type SeenCache struct {
+	mu      sync.RWMutex
+	entries map[string]time.Time
+	ttl     time.Duration
+}
+
+// NewSeenCache creates a seen cache with the given TTL for entries.
+func NewSeenCache(ttl time.Duration) *SeenCache {
+	return &SeenCache{
+		entries: make(map[string]time.Time),
+		ttl:     ttl,
+	}
+}
+
+// Has returns true if the messageID was already seen (read-only).
+func (s *SeenCache) Has(messageID string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	_, ok := s.entries[messageID]
+	return ok
+}
+
+// Check returns true if the messageID was already seen.
+// If not seen, it marks the messageID as seen and returns false.
+// This is an atomic test-and-set operation.
+func (s *SeenCache) Check(messageID string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.entries[messageID]; ok {
+		return true
+	}
+	s.entries[messageID] = time.Now()
+	return false
+}
+
+// Len returns the number of entries (for testing).
+func (s *SeenCache) Len() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.entries)
+}
+
+// CleanupLoop periodically removes expired entries until done is closed.
+func (s *SeenCache) CleanupLoop(done <-chan struct{}, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			s.cleanup()
+		case <-done:
+			return
+		}
+	}
+}
+
+func (s *SeenCache) cleanup() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cutoff := time.Now().Add(-s.ttl)
+	for id, t := range s.entries {
+		if t.Before(cutoff) {
+			delete(s.entries, id)
+		}
+	}
+}

--- a/internal/gossip/seen_test.go
+++ b/internal/gossip/seen_test.go
@@ -1,0 +1,57 @@
+package gossip
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSeenCacheBasic(t *testing.T) {
+	sc := NewSeenCache(5 * time.Minute)
+
+	// First check: not seen
+	if sc.Check("msg-1") {
+		t.Fatal("expected msg-1 to not be seen")
+	}
+
+	// Second check: seen
+	if !sc.Check("msg-1") {
+		t.Fatal("expected msg-1 to be seen")
+	}
+
+	// Different ID: not seen
+	if sc.Check("msg-2") {
+		t.Fatal("expected msg-2 to not be seen")
+	}
+}
+
+func TestSeenCacheLen(t *testing.T) {
+	sc := NewSeenCache(5 * time.Minute)
+	sc.Check("a")
+	sc.Check("b")
+	sc.Check("c")
+	if sc.Len() != 3 {
+		t.Fatalf("expected 3, got %d", sc.Len())
+	}
+}
+
+func TestSeenCacheCleanup(t *testing.T) {
+	sc := NewSeenCache(50 * time.Millisecond)
+
+	sc.Check("msg-1")
+	if sc.Len() != 1 {
+		t.Fatalf("expected 1 entry, got %d", sc.Len())
+	}
+
+	// Wait for TTL to expire
+	time.Sleep(100 * time.Millisecond)
+	sc.cleanup()
+
+	if sc.Len() != 0 {
+		t.Fatalf("expected 0 entries after cleanup, got %d", sc.Len())
+	}
+
+	// msg-1 should be "new" again
+	if sc.Check("msg-1") {
+		t.Fatal("expected msg-1 to not be seen after cleanup")
+	}
+}

--- a/internal/store/bolt/bolt_test.go
+++ b/internal/store/bolt/bolt_test.go
@@ -1,0 +1,235 @@
+package bolt
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func tempStore(t *testing.T) *Store {
+	t.Helper()
+	dir := t.TempDir()
+	s, err := Open(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { s.Close() })
+	return s
+}
+
+var testBucket = []byte("test-bucket")
+
+func TestOpenClose(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.db")
+	s, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+	// File should exist
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("db file should exist: %v", err)
+	}
+}
+
+func TestOpenInvalidPath(t *testing.T) {
+	_, err := Open("/nonexistent/dir/test.db")
+	if err == nil {
+		t.Fatal("opening db in nonexistent dir should fail")
+	}
+}
+
+func TestSetAndGet(t *testing.T) {
+	s := tempStore(t)
+
+	if err := s.Set(testBucket, []byte("key1"), []byte("val1")); err != nil {
+		t.Fatal(err)
+	}
+
+	val, err := s.Get(testBucket, []byte("key1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(val) != "val1" {
+		t.Fatalf("expected val1, got %q", val)
+	}
+}
+
+func TestGetNonexistentBucket(t *testing.T) {
+	s := tempStore(t)
+	val, err := s.Get([]byte("no-bucket"), []byte("key"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if val != nil {
+		t.Fatalf("expected nil for nonexistent bucket, got %q", val)
+	}
+}
+
+func TestGetNonexistentKey(t *testing.T) {
+	s := tempStore(t)
+	if err := s.Set(testBucket, []byte("other"), []byte("val")); err != nil {
+		t.Fatal(err)
+	}
+	val, err := s.Get(testBucket, []byte("missing"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if val != nil {
+		t.Fatalf("expected nil for missing key, got %q", val)
+	}
+}
+
+func TestSetOverwrite(t *testing.T) {
+	s := tempStore(t)
+	if err := s.Set(testBucket, []byte("k"), []byte("v1")); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Set(testBucket, []byte("k"), []byte("v2")); err != nil {
+		t.Fatal(err)
+	}
+	val, err := s.Get(testBucket, []byte("k"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(val) != "v2" {
+		t.Fatalf("expected v2 after overwrite, got %q", val)
+	}
+}
+
+func TestDelete(t *testing.T) {
+	s := tempStore(t)
+	if err := s.Set(testBucket, []byte("k"), []byte("v")); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Delete(testBucket, []byte("k")); err != nil {
+		t.Fatal(err)
+	}
+	val, err := s.Get(testBucket, []byte("k"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if val != nil {
+		t.Fatalf("expected nil after delete, got %q", val)
+	}
+}
+
+func TestDeleteNonexistentBucket(t *testing.T) {
+	s := tempStore(t)
+	// Should not error when bucket doesn't exist
+	if err := s.Delete([]byte("no-bucket"), []byte("key")); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestForEach(t *testing.T) {
+	s := tempStore(t)
+	keys := []string{"a", "b", "c"}
+	for _, k := range keys {
+		if err := s.Set(testBucket, []byte(k), []byte("val-"+k)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	seen := make(map[string]string)
+	err := s.ForEach(testBucket, func(k, v []byte) error {
+		seen[string(k)] = string(v)
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(seen) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(seen))
+	}
+	for _, k := range keys {
+		if seen[k] != "val-"+k {
+			t.Fatalf("expected val-%s, got %q", k, seen[k])
+		}
+	}
+}
+
+func TestForEachNonexistentBucket(t *testing.T) {
+	s := tempStore(t)
+	count := 0
+	err := s.ForEach([]byte("no-bucket"), func(k, v []byte) error {
+		count++
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Fatal("iterating empty/nonexistent bucket should yield 0 entries")
+	}
+}
+
+func TestSnapshot(t *testing.T) {
+	s := tempStore(t)
+	if err := s.Set(testBucket, []byte("x"), []byte("1")); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Set(testBucket, []byte("y"), []byte("2")); err != nil {
+		t.Fatal(err)
+	}
+
+	snap, err := s.Snapshot(testBucket)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snap) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(snap))
+	}
+	if string(snap["x"]) != "1" || string(snap["y"]) != "2" {
+		t.Fatalf("unexpected snapshot content: %v", snap)
+	}
+}
+
+func TestSnapshotNonexistentBucket(t *testing.T) {
+	s := tempStore(t)
+	snap, err := s.Snapshot([]byte("no-bucket"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snap) != 0 {
+		t.Fatalf("expected empty snapshot, got %d entries", len(snap))
+	}
+}
+
+func TestSnapshotReturnsCopy(t *testing.T) {
+	s := tempStore(t)
+	if err := s.Set(testBucket, []byte("k"), []byte("original")); err != nil {
+		t.Fatal(err)
+	}
+
+	snap, _ := s.Snapshot(testBucket)
+	// Mutating the snapshot should not affect the store
+	snap["k"][0] = 'X'
+
+	val, _ := s.Get(testBucket, []byte("k"))
+	if string(val) != "original" {
+		t.Fatal("snapshot mutation should not affect store")
+	}
+}
+
+func TestMultipleBuckets(t *testing.T) {
+	s := tempStore(t)
+	b1 := []byte("bucket1")
+	b2 := []byte("bucket2")
+
+	if err := s.Set(b1, []byte("k"), []byte("v1")); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Set(b2, []byte("k"), []byte("v2")); err != nil {
+		t.Fatal(err)
+	}
+
+	v1, _ := s.Get(b1, []byte("k"))
+	v2, _ := s.Get(b2, []byte("k"))
+	if string(v1) != "v1" || string(v2) != "v2" {
+		t.Fatal("buckets should be isolated")
+	}
+}

--- a/internal/transport/gossip_integration_test.go
+++ b/internal/transport/gossip_integration_test.go
@@ -1,0 +1,449 @@
+package transport_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"micelio/internal/config"
+	"micelio/internal/identity"
+	"micelio/internal/partyline"
+	"micelio/internal/transport"
+)
+
+// TestGossipChainRelay verifies multi-hop gossip propagation.
+// Topology: A─B─C (chain, no discovery). A and C are NOT directly connected.
+// A sends a message → it should reach C via gossip through B.
+func TestGossipChainRelay(t *testing.T) {
+	type testNode struct {
+		id      *identity.Identity
+		hub     *partyline.Hub
+		mgr     *transport.Manager
+		ctx     context.Context
+		cancel  context.CancelFunc
+		session *partyline.Session
+	}
+
+	makeNode := func(name string) testNode {
+		id, err := identity.Load(t.TempDir())
+		if err != nil {
+			t.Fatalf("identity %s: %v", name, err)
+		}
+		hub := partyline.NewHub(name)
+		ctx, cancel := context.WithCancel(context.Background())
+		return testNode{id: id, hub: hub, ctx: ctx, cancel: cancel}
+	}
+
+	cleanup := func(n *testNode) {
+		if n.session != nil {
+			n.hub.Leave(n.session)
+		}
+		if n.mgr != nil {
+			n.mgr.Stop()
+		}
+		n.cancel()
+		n.hub.Stop()
+	}
+
+	nodeA := makeNode("node-a")
+	nodeB := makeNode("node-b")
+	nodeC := makeNode("node-c")
+	defer func() {
+		cleanup(&nodeC)
+		cleanup(&nodeB)
+		cleanup(&nodeA)
+	}()
+
+	// Start B (center) — listens, no bootstrap
+	cfgB := &config.Config{
+		Node: config.NodeConfig{Name: "node-b"},
+		Network: config.NetworkConfig{
+			Listen:            "127.0.0.1:0",
+			ExchangeInterval:  noDiscovery,
+			DiscoveryInterval: noDiscovery,
+		},
+	}
+	mgrB, err := transport.NewManager(cfgB, nodeB.id, nodeB.hub, nil)
+	if err != nil {
+		t.Fatalf("manager B: %v", err)
+	}
+	nodeB.mgr = mgrB
+	go nodeB.hub.Run()
+	go mgrB.Start(nodeB.ctx)
+
+	deadline := time.Now().Add(5 * time.Second)
+	for mgrB.Addr() == "" && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	addrB := mgrB.Addr()
+
+	// Start A — bootstraps to B only
+	cfgA := &config.Config{
+		Node: config.NodeConfig{Name: "node-a"},
+		Network: config.NetworkConfig{
+			Listen:            "127.0.0.1:0",
+			Bootstrap:         []string{addrB},
+			ExchangeInterval:  noDiscovery,
+			DiscoveryInterval: noDiscovery,
+		},
+	}
+	mgrA, err := transport.NewManager(cfgA, nodeA.id, nodeA.hub, nil)
+	if err != nil {
+		t.Fatalf("manager A: %v", err)
+	}
+	nodeA.mgr = mgrA
+	go nodeA.hub.Run()
+	go mgrA.Start(nodeA.ctx)
+
+	// Start C — bootstraps to B only (does NOT know A)
+	cfgC := &config.Config{
+		Node: config.NodeConfig{Name: "node-c"},
+		Network: config.NetworkConfig{
+			Listen:            "127.0.0.1:0",
+			Bootstrap:         []string{addrB},
+			ExchangeInterval:  noDiscovery,
+			DiscoveryInterval: noDiscovery,
+		},
+	}
+	mgrC, err := transport.NewManager(cfgC, nodeC.id, nodeC.hub, nil)
+	if err != nil {
+		t.Fatalf("manager C: %v", err)
+	}
+	nodeC.mgr = mgrC
+	go nodeC.hub.Run()
+	go mgrC.Start(nodeC.ctx)
+
+	// Wait for A↔B and B↔C connections
+	deadline = time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if mgrA.PeerCount() >= 1 && mgrC.PeerCount() >= 1 && mgrB.PeerCount() >= 2 {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if mgrB.PeerCount() < 2 {
+		t.Fatalf("B has %d peers, want 2", mgrB.PeerCount())
+	}
+
+	// A and C should NOT be directly connected (no discovery, no bootstrap between them)
+	if mgrA.PeerCount() != 1 {
+		t.Fatalf("A has %d peers, want 1 (only B)", mgrA.PeerCount())
+	}
+	if mgrC.PeerCount() != 1 {
+		t.Fatalf("C has %d peers, want 1 (only B)", mgrC.PeerCount())
+	}
+
+	// Join sessions
+	nodeA.session = nodeA.hub.Join("alice")
+	nodeB.session = nodeB.hub.Join("bob")
+	nodeC.session = nodeC.hub.Join("carol")
+	drainFor(nodeA.session.Send, 200*time.Millisecond)
+	drainFor(nodeB.session.Send, 200*time.Millisecond)
+	drainFor(nodeC.session.Send, 200*time.Millisecond)
+
+	// A sends a message
+	nodeA.hub.Broadcast(nodeA.session, "hello from A")
+
+	// B should receive (directly connected to A)
+	if msg := waitForMsg(nodeB.session.Send, 5*time.Second, "alice", "hello from A"); msg == "" {
+		t.Fatal("B did not receive message from A")
+	}
+
+	// C should receive via gossip through B!
+	if msg := waitForMsg(nodeC.session.Send, 5*time.Second, "alice", "hello from A"); msg == "" {
+		t.Fatal("C did not receive message from A via gossip through B")
+	}
+
+	// Verify reverse: C sends, A receives via B
+	drainFor(nodeA.session.Send, 200*time.Millisecond)
+	drainFor(nodeB.session.Send, 200*time.Millisecond)
+	drainFor(nodeC.session.Send, 200*time.Millisecond)
+
+	nodeC.hub.Broadcast(nodeC.session, "reply from C")
+	if msg := waitForMsg(nodeA.session.Send, 5*time.Second, "carol", "reply from C"); msg == "" {
+		t.Fatal("A did not receive message from C via gossip through B")
+	}
+}
+
+// TestGossipDedup verifies that the same message is not delivered twice even
+// when it arrives from multiple peers.
+func TestGossipDedup(t *testing.T) {
+	type testNode struct {
+		id      *identity.Identity
+		hub     *partyline.Hub
+		mgr     *transport.Manager
+		ctx     context.Context
+		cancel  context.CancelFunc
+		session *partyline.Session
+	}
+
+	makeNode := func(name string) testNode {
+		id, err := identity.Load(t.TempDir())
+		if err != nil {
+			t.Fatalf("identity %s: %v", name, err)
+		}
+		hub := partyline.NewHub(name)
+		ctx, cancel := context.WithCancel(context.Background())
+		return testNode{id: id, hub: hub, ctx: ctx, cancel: cancel}
+	}
+
+	cleanup := func(n *testNode) {
+		if n.session != nil {
+			n.hub.Leave(n.session)
+		}
+		if n.mgr != nil {
+			n.mgr.Stop()
+		}
+		n.cancel()
+		n.hub.Stop()
+	}
+
+	// Triangle topology: A↔B, A↔C, B↔C (full mesh)
+	// A sends a message → B and C both forward to each other, but dedup prevents double delivery.
+	nodeA := makeNode("node-a")
+	nodeB := makeNode("node-b")
+	nodeC := makeNode("node-c")
+	defer func() {
+		cleanup(&nodeC)
+		cleanup(&nodeB)
+		cleanup(&nodeA)
+	}()
+
+	// Start A
+	cfgA := &config.Config{
+		Node: config.NodeConfig{Name: "node-a"},
+		Network: config.NetworkConfig{
+			Listen:            "127.0.0.1:0",
+			ExchangeInterval:  noDiscovery,
+			DiscoveryInterval: noDiscovery,
+		},
+	}
+	mgrA, err := transport.NewManager(cfgA, nodeA.id, nodeA.hub, nil)
+	if err != nil {
+		t.Fatalf("manager A: %v", err)
+	}
+	nodeA.mgr = mgrA
+	go nodeA.hub.Run()
+	go mgrA.Start(nodeA.ctx)
+
+	deadline := time.Now().Add(5 * time.Second)
+	for mgrA.Addr() == "" && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	addrA := mgrA.Addr()
+
+	// Start B — bootstraps to A
+	cfgB := &config.Config{
+		Node: config.NodeConfig{Name: "node-b"},
+		Network: config.NetworkConfig{
+			Listen:            "127.0.0.1:0",
+			Bootstrap:         []string{addrA},
+			ExchangeInterval:  noDiscovery,
+			DiscoveryInterval: noDiscovery,
+		},
+	}
+	mgrB, err := transport.NewManager(cfgB, nodeB.id, nodeB.hub, nil)
+	if err != nil {
+		t.Fatalf("manager B: %v", err)
+	}
+	nodeB.mgr = mgrB
+	go nodeB.hub.Run()
+	go mgrB.Start(nodeB.ctx)
+
+	// Wait for A↔B
+	deadline = time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if mgrA.PeerCount() >= 1 && mgrB.PeerCount() >= 1 {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// Start C — bootstraps to both A and B (forms triangle)
+	cfgC := &config.Config{
+		Node: config.NodeConfig{Name: "node-c"},
+		Network: config.NetworkConfig{
+			Listen:            "127.0.0.1:0",
+			Bootstrap:         []string{addrA, mgrB.Addr()},
+			ExchangeInterval:  noDiscovery,
+			DiscoveryInterval: noDiscovery,
+		},
+	}
+	mgrC, err := transport.NewManager(cfgC, nodeC.id, nodeC.hub, nil)
+	if err != nil {
+		t.Fatalf("manager C: %v", err)
+	}
+	nodeC.mgr = mgrC
+	go nodeC.hub.Run()
+	go mgrC.Start(nodeC.ctx)
+
+	// Wait for full mesh
+	deadline = time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if mgrA.PeerCount() >= 2 && mgrB.PeerCount() >= 2 && mgrC.PeerCount() >= 2 {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if mgrC.PeerCount() < 2 {
+		t.Fatalf("mesh not formed: A=%d B=%d C=%d", mgrA.PeerCount(), mgrB.PeerCount(), mgrC.PeerCount())
+	}
+
+	// Join sessions
+	nodeA.session = nodeA.hub.Join("alice")
+	nodeB.session = nodeB.hub.Join("bob")
+	nodeC.session = nodeC.hub.Join("carol")
+	drainFor(nodeA.session.Send, 200*time.Millisecond)
+	drainFor(nodeB.session.Send, 200*time.Millisecond)
+	drainFor(nodeC.session.Send, 200*time.Millisecond)
+
+	// A sends "unique-msg". B and C receive it directly from A.
+	// B may try to forward to C and vice versa, but dedup ensures single delivery.
+	nodeA.hub.Broadcast(nodeA.session, "unique-msg")
+
+	// B receives exactly once
+	if msg := waitForMsg(nodeB.session.Send, 5*time.Second, "alice", "unique-msg"); msg == "" {
+		t.Fatal("B did not receive the message")
+	}
+	// Check no duplicate delivery (wait a bit and see if another comes)
+	if msg := waitForMsg(nodeB.session.Send, 500*time.Millisecond, "alice", "unique-msg"); msg != "" {
+		t.Fatal("B received duplicate message")
+	}
+
+	// C receives exactly once
+	if msg := waitForMsg(nodeC.session.Send, 5*time.Second, "alice", "unique-msg"); msg == "" {
+		t.Fatal("C did not receive the message")
+	}
+	if msg := waitForMsg(nodeC.session.Send, 500*time.Millisecond, "alice", "unique-msg"); msg != "" {
+		t.Fatal("C received duplicate message")
+	}
+}
+
+// TestGossipDefaultHopCountChain verifies multi-hop gossip propagation using
+// the engine's default hop_count in a 5-node chain topology.
+// Topology: A─B─C─D─E (chain). A and E are NOT directly connected.
+// The message is expected to traverse all intermediate hops.
+// Strict hop_count=0/1 behavior is validated in the gossip engine unit tests
+// (e.g., TestEngineHopCountZero). Here we exercise the default hop_count
+// end-to-end over a realistic 4-hop chain.
+func TestGossipDefaultHopCountChain(t *testing.T) {
+
+	const N = 5
+	type testNode struct {
+		id      *identity.Identity
+		hub     *partyline.Hub
+		mgr     *transport.Manager
+		ctx     context.Context
+		cancel  context.CancelFunc
+		session *partyline.Session
+	}
+
+	nodes := make([]testNode, N)
+	for i := 0; i < N; i++ {
+		id, err := identity.Load(t.TempDir())
+		if err != nil {
+			t.Fatalf("identity node-%d: %v", i, err)
+		}
+		hub := partyline.NewHub(fmt.Sprintf("node-%d", i))
+		ctx, cancel := context.WithCancel(context.Background())
+		nodes[i] = testNode{id: id, hub: hub, ctx: ctx, cancel: cancel}
+	}
+
+	defer func() {
+		for i := N - 1; i >= 0; i-- {
+			if nodes[i].session != nil {
+				nodes[i].hub.Leave(nodes[i].session)
+			}
+			if nodes[i].mgr != nil {
+				nodes[i].mgr.Stop()
+			}
+			nodes[i].cancel()
+			nodes[i].hub.Stop()
+		}
+	}()
+
+	// Build chain: 0─1─2─3─4, no discovery (pure chain)
+	addrs := make([]string, N)
+	for i := N - 1; i >= 0; i-- {
+		var bootstrap []string
+		if i < N-1 {
+			bootstrap = []string{addrs[i+1]}
+		}
+		cfg := &config.Config{
+			Node: config.NodeConfig{Name: fmt.Sprintf("node-%d", i)},
+			Network: config.NetworkConfig{
+				Listen:            "127.0.0.1:0",
+				Bootstrap:         bootstrap,
+				ExchangeInterval:  noDiscovery,
+				DiscoveryInterval: noDiscovery,
+			},
+		}
+		mgr, err := transport.NewManager(cfg, nodes[i].id, nodes[i].hub, nil)
+		if err != nil {
+			t.Fatalf("manager %d: %v", i, err)
+		}
+		nodes[i].mgr = mgr
+		go nodes[i].hub.Run()
+		go mgr.Start(nodes[i].ctx)
+
+		deadline := time.Now().Add(5 * time.Second)
+		for mgr.Addr() == "" && time.Now().Before(deadline) {
+			time.Sleep(10 * time.Millisecond)
+		}
+		addrs[i] = mgr.Addr()
+	}
+
+	// Wait for chain links
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		allLinked := true
+		for i := 0; i < N; i++ {
+			if nodes[i].mgr.PeerCount() == 0 {
+				allLinked = false
+				break
+			}
+		}
+		if allLinked {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// Each node has the expected number of peers for the chain topology (no discovery)
+	for i := 0; i < N; i++ {
+		expected := 1
+		if i > 0 && i < N-1 {
+			expected = 2 // middle nodes have two neighbors
+		}
+		got := nodes[i].mgr.PeerCount()
+		if got != expected {
+			t.Fatalf("node %d has %d peers; expected %d (chain not formed as expected)", i, got, expected)
+		}
+	}
+
+	// Join sessions
+	nicks := []string{"alice", "bob", "carol", "dave", "eve"}
+	for i := 0; i < N; i++ {
+		nodes[i].session = nodes[i].hub.Join(nicks[i])
+	}
+	for i := 0; i < N; i++ {
+		drainFor(nodes[i].session.Send, 200*time.Millisecond)
+	}
+
+	// Node 0 sends — should reach node 4 via gossip through the chain (4 hops)
+	nodes[0].hub.Broadcast(nodes[0].session, "chain-gossip-test")
+
+	msg := waitForMsg(nodes[N-1].session.Send, 10*time.Second, nicks[0], "chain-gossip-test")
+	if msg == "" {
+		t.Fatal("node 4 did not receive message from node 0 via gossip chain")
+	}
+
+	// All intermediate nodes should also have received it
+	for i := 1; i < N-1; i++ {
+		msg := waitForMsg(nodes[i].session.Send, 5*time.Second, nicks[0], "chain-gossip-test")
+		if msg == "" {
+			t.Fatalf("node %d did not receive message from node 0", i)
+		}
+	}
+}

--- a/internal/transport/peer_internal_test.go
+++ b/internal/transport/peer_internal_test.go
@@ -145,8 +145,8 @@ func TestEnvelopeSignDataDeterministic(t *testing.T) {
 		Payload:   []byte("hello"),
 	}
 
-	d1 := envelopeSignData(env)
-	d2 := envelopeSignData(env)
+	d1 := pb.EnvelopeSignData(env)
+	d2 := pb.EnvelopeSignData(env)
 	if len(d1) != len(d2) {
 		t.Fatal("sign data not deterministic")
 	}

--- a/pkg/proto/envelope.go
+++ b/pkg/proto/envelope.go
@@ -1,0 +1,46 @@
+package proto
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/binary"
+)
+
+// SignEnvelope signs an envelope with the given ED25519 private key.
+// The signed data is: message_id + sender_id + lamport_ts + msg_type + payload.
+// hop_count and sender_pubkey are excluded so that intermediate nodes can decrement
+// hop_count and include the public key for auto-learn without invalidating the
+// originator's signature.
+func SignEnvelope(env *Envelope, privKey ed25519.PrivateKey) {
+	if len(privKey) != ed25519.PrivateKeySize {
+		env.Signature = nil
+		return
+	}
+	env.Signature = ed25519.Sign(privKey, EnvelopeSignData(env))
+}
+
+// VerifyEnvelope verifies the ED25519 signature on an envelope.
+func VerifyEnvelope(env *Envelope, pubKey ed25519.PublicKey) bool {
+	if len(pubKey) != ed25519.PublicKeySize {
+		return false
+	}
+	if len(env.Signature) != ed25519.SignatureSize {
+		return false
+	}
+	return ed25519.Verify(pubKey, EnvelopeSignData(env), env.Signature)
+}
+
+// EnvelopeSignData returns the bytes that are signed/verified for an envelope.
+func EnvelopeSignData(env *Envelope) []byte {
+	var buf bytes.Buffer
+	buf.WriteString(env.MessageId)
+	buf.WriteString(env.SenderId)
+	var ts [8]byte
+	binary.BigEndian.PutUint64(ts[:], env.LamportTs)
+	buf.Write(ts[:])
+	var mt [4]byte
+	binary.BigEndian.PutUint32(mt[:], env.MsgType)
+	buf.Write(mt[:])
+	buf.Write(env.Payload)
+	return buf.Bytes()
+}

--- a/pkg/proto/envelope_test.go
+++ b/pkg/proto/envelope_test.go
@@ -1,0 +1,144 @@
+package proto
+
+import (
+	"crypto/ed25519"
+	"testing"
+)
+
+func makeTestEnvelope() *Envelope {
+	return &Envelope{
+		MessageId: "test-msg-001",
+		SenderId:  "test-sender",
+		LamportTs: 42,
+		MsgType:   3,
+		HopCount:  5,
+		Payload:   []byte("hello world"),
+	}
+}
+
+func TestSignAndVerifyEnvelope(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	env := makeTestEnvelope()
+	SignEnvelope(env, priv)
+
+	if len(env.Signature) != ed25519.SignatureSize {
+		t.Fatalf("expected signature length %d, got %d", ed25519.SignatureSize, len(env.Signature))
+	}
+
+	if !VerifyEnvelope(env, pub) {
+		t.Fatal("valid signature should verify")
+	}
+}
+
+func TestSignEnvelope_InvalidKeyLength(t *testing.T) {
+	env := makeTestEnvelope()
+	SignEnvelope(env, []byte("short-key"))
+
+	if env.Signature != nil {
+		t.Fatal("signing with invalid key should leave signature nil")
+	}
+}
+
+func TestVerifyEnvelope_InvalidPubKeyLength(t *testing.T) {
+	env := makeTestEnvelope()
+	env.Signature = make([]byte, ed25519.SignatureSize)
+	if VerifyEnvelope(env, []byte("short")) {
+		t.Fatal("verify with invalid pubkey length should return false")
+	}
+}
+
+func TestVerifyEnvelope_InvalidSignatureLength(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(nil)
+	env := makeTestEnvelope()
+	env.Signature = []byte("bad-sig")
+	if VerifyEnvelope(env, pub) {
+		t.Fatal("verify with invalid signature length should return false")
+	}
+}
+
+func TestVerifyEnvelope_WrongKey(t *testing.T) {
+	_, priv, _ := ed25519.GenerateKey(nil)
+	otherPub, _, _ := ed25519.GenerateKey(nil)
+
+	env := makeTestEnvelope()
+	SignEnvelope(env, priv)
+
+	if VerifyEnvelope(env, otherPub) {
+		t.Fatal("verify with wrong key should return false")
+	}
+}
+
+func TestVerifyEnvelope_TamperedPayload(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+
+	env := makeTestEnvelope()
+	SignEnvelope(env, priv)
+
+	env.Payload = []byte("tampered")
+	if VerifyEnvelope(env, pub) {
+		t.Fatal("verify with tampered payload should return false")
+	}
+}
+
+func TestVerifyEnvelope_TamperedSenderId(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+
+	env := makeTestEnvelope()
+	SignEnvelope(env, priv)
+
+	env.SenderId = "attacker"
+	if VerifyEnvelope(env, pub) {
+		t.Fatal("verify with tampered sender_id should return false")
+	}
+}
+
+func TestVerifyEnvelope_HopCountExcludedFromSignature(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+
+	env := makeTestEnvelope()
+	SignEnvelope(env, priv)
+
+	// Changing hop_count should NOT invalidate the signature
+	env.HopCount = 1
+	if !VerifyEnvelope(env, pub) {
+		t.Fatal("hop_count change should not invalidate signature")
+	}
+}
+
+func TestVerifyEnvelope_SenderPubkeyExcludedFromSignature(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+
+	env := makeTestEnvelope()
+	SignEnvelope(env, priv)
+
+	// Changing sender_pubkey should NOT invalidate the signature
+	env.SenderPubkey = []byte("some-other-pubkey-bytes")
+	if !VerifyEnvelope(env, pub) {
+		t.Fatal("sender_pubkey change should not invalidate signature")
+	}
+}
+
+func TestEnvelopeSignData_Deterministic(t *testing.T) {
+	env := makeTestEnvelope()
+	d1 := EnvelopeSignData(env)
+	d2 := EnvelopeSignData(env)
+	if string(d1) != string(d2) {
+		t.Fatal("EnvelopeSignData should be deterministic")
+	}
+}
+
+func TestEnvelopeSignData_DifferentForDifferentFields(t *testing.T) {
+	env1 := makeTestEnvelope()
+	env2 := makeTestEnvelope()
+	env2.MsgType = 99
+
+	d1 := EnvelopeSignData(env1)
+	d2 := EnvelopeSignData(env2)
+	if string(d1) == string(d2) {
+		t.Fatal("different msg_type should produce different sign data")
+	}
+}

--- a/pkg/proto/micelio.pb.go
+++ b/pkg/proto/micelio.pb.go
@@ -25,13 +25,14 @@ const (
 // msg_type is numeric for extensibility: core 1-99, plugin 1000+.
 type Envelope struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	MessageId     string                 `protobuf:"bytes,1,opt,name=message_id,json=messageId,proto3" json:"message_id,omitempty"`  // UUID v4, unique per message
-	SenderId      string                 `protobuf:"bytes,2,opt,name=sender_id,json=senderId,proto3" json:"sender_id,omitempty"`     // node_id of originator
-	LamportTs     uint64                 `protobuf:"varint,3,opt,name=lamport_ts,json=lamportTs,proto3" json:"lamport_ts,omitempty"` // Lamport clock (reserved, unused in Phase 2)
-	HopCount      uint32                 `protobuf:"varint,4,opt,name=hop_count,json=hopCount,proto3" json:"hop_count,omitempty"`    // decremented at each hop
-	MsgType       uint32                 `protobuf:"varint,5,opt,name=msg_type,json=msgType,proto3" json:"msg_type,omitempty"`       // payload type
-	Payload       []byte                 `protobuf:"bytes,6,opt,name=payload,proto3" json:"payload,omitempty"`                       // serialized inner message
-	Signature     []byte                 `protobuf:"bytes,7,opt,name=signature,proto3" json:"signature,omitempty"`                   // ED25519 signature (excludes hop_count)
+	MessageId     string                 `protobuf:"bytes,1,opt,name=message_id,json=messageId,proto3" json:"message_id,omitempty"`          // UUID v4, unique per message
+	SenderId      string                 `protobuf:"bytes,2,opt,name=sender_id,json=senderId,proto3" json:"sender_id,omitempty"`             // node_id of originator
+	LamportTs     uint64                 `protobuf:"varint,3,opt,name=lamport_ts,json=lamportTs,proto3" json:"lamport_ts,omitempty"`         // Lamport clock (reserved, unused in Phase 2)
+	HopCount      uint32                 `protobuf:"varint,4,opt,name=hop_count,json=hopCount,proto3" json:"hop_count,omitempty"`            // decremented at each hop
+	MsgType       uint32                 `protobuf:"varint,5,opt,name=msg_type,json=msgType,proto3" json:"msg_type,omitempty"`               // payload type
+	Payload       []byte                 `protobuf:"bytes,6,opt,name=payload,proto3" json:"payload,omitempty"`                               // serialized inner message
+	Signature     []byte                 `protobuf:"bytes,7,opt,name=signature,proto3" json:"signature,omitempty"`                           // ED25519 signature (excludes hop_count and sender_pubkey)
+	SenderPubkey  []byte                 `protobuf:"bytes,8,opt,name=sender_pubkey,json=senderPubkey,proto3" json:"sender_pubkey,omitempty"` // raw 32-byte ED25519 public key of originator
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -111,6 +112,13 @@ func (x *Envelope) GetPayload() []byte {
 func (x *Envelope) GetSignature() []byte {
 	if x != nil {
 		return x.Signature
+	}
+	return nil
+}
+
+func (x *Envelope) GetSenderPubkey() []byte {
+	if x != nil {
+		return x.SenderPubkey
 	}
 	return nil
 }
@@ -474,7 +482,7 @@ var File_proto_micelio_proto protoreflect.FileDescriptor
 
 const file_proto_micelio_proto_rawDesc = "" +
 	"\n" +
-	"\x13proto/micelio.proto\x12\amicelio\"\xd5\x01\n" +
+	"\x13proto/micelio.proto\x12\amicelio\"\xfa\x01\n" +
 	"\bEnvelope\x12\x1d\n" +
 	"\n" +
 	"message_id\x18\x01 \x01(\tR\tmessageId\x12\x1b\n" +
@@ -484,7 +492,8 @@ const file_proto_micelio_proto_rawDesc = "" +
 	"\thop_count\x18\x04 \x01(\rR\bhopCount\x12\x19\n" +
 	"\bmsg_type\x18\x05 \x01(\rR\amsgType\x12\x18\n" +
 	"\apayload\x18\x06 \x01(\fR\apayload\x12\x1c\n" +
-	"\tsignature\x18\a \x01(\fR\tsignature\"\xb8\x01\n" +
+	"\tsignature\x18\a \x01(\fR\tsignature\x12#\n" +
+	"\rsender_pubkey\x18\b \x01(\fR\fsenderPubkey\"\xb8\x01\n" +
 	"\tPeerHello\x12\x17\n" +
 	"\anode_id\x18\x01 \x01(\tR\x06nodeId\x12\x18\n" +
 	"\aversion\x18\x02 \x01(\tR\aversion\x12\x12\n" +

--- a/proto/micelio.proto
+++ b/proto/micelio.proto
@@ -6,13 +6,14 @@ option go_package = "micelio/pkg/proto";
 // Envelope wraps every message on the wire.
 // msg_type is numeric for extensibility: core 1-99, plugin 1000+.
 message Envelope {
-    string message_id = 1;       // UUID v4, unique per message
-    string sender_id  = 2;       // node_id of originator
-    uint64 lamport_ts = 3;       // Lamport clock (reserved, unused in Phase 2)
-    uint32 hop_count  = 4;       // decremented at each hop
-    uint32 msg_type   = 5;       // payload type
-    bytes  payload    = 6;       // serialized inner message
-    bytes  signature  = 7;       // ED25519 signature (excludes hop_count)
+    string message_id   = 1;     // UUID v4, unique per message
+    string sender_id    = 2;     // node_id of originator
+    uint64 lamport_ts   = 3;     // Lamport clock (reserved, unused in Phase 2)
+    uint32 hop_count    = 4;     // decremented at each hop
+    uint32 msg_type     = 5;     // payload type
+    bytes  payload      = 6;     // serialized inner message
+    bytes  signature    = 7;     // ED25519 signature (excludes hop_count and sender_pubkey)
+    bytes  sender_pubkey = 8;    // raw 32-byte ED25519 public key of originator
 }
 
 // PeerHello is sent by the initiator after the Noise handshake.


### PR DESCRIPTION
## Summary

Implements **Phase 4** of the Micelio roadmap: a gossip protocol that enables multi-hop message propagation across the mesh network. Closes #3.

### Gossip Engine (`internal/gossip/`)

New package with four core components:

- **`Engine`** — Central gossip processor with an 8-step incoming message pipeline:
  1. Reject malformed envelopes (empty `message_id` / `sender_id`)
  2. Read-only dedup check (`SeenCache.Has`)
  3. Sender key lookup in keyring (with auto-learn fallback)
  4. ED25519 signature verification
  5. Per-sender rate limiting — before marking seen, so rate-limited messages can be retried
  6. Atomic mark-as-seen (`SeenCache.Check`) — only after verification + rate limit pass
  7. Local delivery to registered message handler
  8. Hop-count-limited forwarding to random peer subset (fanout=3, excluding sender)

  `Stop()` is idempotent via `sync.Once`.

- **`SeenCache`** — Message ID deduplication with 5-minute TTL and periodic cleanup. Uses `sync.RWMutex` for read-heavy workload (concurrent `Has()` checks). Two-phase design ensures dropped messages (unknown sender, bad signature, rate-limited) are NOT marked as seen — they can be retried when conditions change.

- **`KeyRing`** — Thread-safe map of node ID → ED25519 public key with trust levels:
  - `TrustDirectlyVerified` (strongest) — learned via Noise handshake / PeerHello
  - `TrustGossipLearned` — learned from `sender_pubkey` envelope field or peer exchange
  - Gossip-learned keys never overwrite directly verified ones
  - Public keys are defensively copied on insert to prevent external mutation

- **`RateLimiter`** — Per-sender token bucket (10 msg/s, burst capacity = 2× rate) with automatic cleanup of idle buckets.

### Auto-Learn Key Discovery

Solves the bootstrap problem in multi-hop gossip: when node A sends a message relayed by B to C, node C may not have A's public key. The `sender_pubkey` field in the Envelope allows C to verify immediately:
1. `sender_pubkey` must be exactly 32 bytes
2. `SHA-256(sender_pubkey)` must equal `sender_id`
3. Key is added to keyring as `TrustGossipLearned`
4. Signature is verified against the learned key

### Transport Integration

- **Fanout loop** in Manager reads from Hub's `remoteSend` channel, wraps in signed Envelope (with `sender_pubkey`), broadcasts via `Engine.Broadcast()`
- **Peer handles** expose `NodeID` + `Send` function for the engine's forwarding logic
- **Message handler registration** for `MsgTypeChat` routes verified payloads to `Hub.DeliverRemote()`
- Peer keys registered as `TrustDirectlyVerified` during PeerHello exchange
- Incoming gossip messages routed from peer recv loop → `Engine.HandleIncoming()`
- **Handshake filtering**: `MsgTypePeerHello` / `MsgTypePeerHelloAck` explicitly dropped in recv loop — never gossip-relayed

### Envelope Changes (`pkg/proto/`)

- Added `sender_pubkey` field (bytes, field 8) to Envelope protobuf
- `sender_pubkey` excluded from signature (like `hop_count`) — auxiliary for key distribution
- `SignEnvelope` clears `env.Signature` on invalid key length (prevents stale signature reuse)
- `VerifyEnvelope` validates both key and signature length before calling `ed25519.Verify`

### Tests

- **36 unit tests** (`internal/gossip/`): dedup, forwarding, rate limiting, keyring trust levels, auto-learn (valid, bad signature, ID mismatch, short key), hop count enforcement, concurrent access, start/stop lifecycle, dropped-message-not-marked-seen, max hops, broadcast with no peers, forward with no candidates, bad pubkey size
- **3 integration tests** (`internal/transport/`):
  - `TestTenNodeStar`: 10-node star topology — center↔spoke, spoke↔spoke via gossip relay
  - `TestOutboundBridge`: two 3-node networks joined by outbound-only bridge — cross-network gossip propagation
  - `TestGossipDefaultHopCountChain`: 5-node chain (A─B─C─D─E) — end-to-end multi-hop propagation
- **11 envelope tests** (`pkg/proto/`): sign/verify, invalid keys, tampered fields, hop_count exclusion, sender_pubkey exclusion, deterministic sign data
- **14 bolt store tests** (`internal/store/bolt/`): full CRUD, snapshot isolation, multiple buckets
- **10 discovery tests** (`internal/transport/`): backoff, safeLastSeen, peer persistence round-trip, invalid record filtering

### Coverage

- `.pb.go` generated files excluded from coverage (CI + Makefile)
- Total coverage: **81.1%** (excluding generated code)

### Documentation

- **`docs/architecture.md`**: full rewrite with gossip engine details, component table, message flow diagrams (local→remote and remote→local), concurrency model table
- **`docs/protocol/messages.md`**: auto-learn section, two-phase dedup explanation, updated chat message flow, `sender_pubkey` field documentation
- **`README.md`**: Phase 4 checked in roadmap, gossip added to project structure

## Test plan
- [x] `go test -race ./...` — all tests pass
- [x] 100x flaky check — gossip: 100/100, transport: 100/100
- [x] `go vet ./...` clean
- [x] All existing Phase 1-3 tests still pass
- [x] Coverage 81.1% (excluding .pb.go)