### PR TITLE
Structured logging with log/slog

### DIFF
--- a/.claude/logging-policy.md
+++ b/.claude/logging-policy.md
@@ -1,0 +1,105 @@
+# Micelio Logging Policy
+
+This document defines the logging conventions for the micelio project.
+All contributors (human or AI) must follow these standards.
+
+## Library
+
+We use Go's stdlib `log/slog` exclusively — no external logging dependencies.
+The thin wrapper in `internal/logging/` provides:
+
+- `logging.Init(level, format)` — call once at startup to configure the global logger.
+- `logging.For(component)` — returns `*slog.Logger` with a `"component"` attribute.
+- `logging.SetLevel(slog.Level)` — change level at runtime (used in tests).
+- `logging.CaptureForTest(t)` — test helper that captures log records for assertions.
+
+## Log Levels
+
+| Level   | Purpose                                      | Examples                                           |
+|---------|----------------------------------------------|----------------------------------------------------|
+| `ERROR` | Unrecoverable failures; something is broken  | Marshal failure, store write failure                |
+| `WARN`  | Anomalous but recoverable; sub-optimal state | Invalid signature, handshake failed, buffer full    |
+| `INFO`  | Important system events; rare, high-signal   | Node started, peer connected/disconnected, listening |
+| `DEBUG` | Verbose diagnostics; used in tests           | Message received/forwarded, dial failed, key learned |
+
+**Rules:**
+- INFO must not flood — if a log line fires more than once per minute in normal operation, it belongs at DEBUG.
+- ERROR means the operation failed and could not recover. If we can continue, use WARN.
+- DEBUG is where most new log lines should go. When in doubt, use DEBUG.
+- Never log at WARN or ERROR in a hot path (per-message processing). Use DEBUG.
+
+## Component Names
+
+Each package gets a component logger with a short, lowercase name:
+
+| Package                    | Component      | Variable  |
+|----------------------------|----------------|-----------|
+| `cmd/micelio`              | *(none)*       | `slog.*`  |
+| `internal/gossip`          | `"gossip"`     | `logger`  |
+| `internal/transport`       | `"transport"`  | `tlog`    |
+| `internal/transport` (discovery) | `"discovery"` | `dlog` |
+| `internal/ssh`             | `"ssh"`        | `sshlog`  |
+| `internal/partyline`       | `"partyline"`  | `plog`    |
+
+New packages should follow this pattern: `var xlog = logging.For("component")`.
+
+## Structured Attributes
+
+Use key-value pairs, not format strings:
+
+```go
+// Good
+logger.Info("peer connected", "peer", nodeID, "direction", "inbound")
+
+// Bad
+logger.Info(fmt.Sprintf("peer connected: %s (inbound)", nodeID))
+```
+
+Common attribute keys:
+
+| Key         | Type     | Description                    |
+|-------------|----------|--------------------------------|
+| `"err"`     | `error`  | Error value                    |
+| `"peer"`    | `string` | Remote node ID (short form OK) |
+| `"addr"`    | `string` | Network address                |
+| `"remote"`  | `any`    | Remote address from net.Conn   |
+| `"msg_id"`  | `string` | Envelope message ID            |
+| `"sender"`  | `string` | Sender node ID                 |
+| `"count"`   | `int`    | Numeric count                  |
+| `"nick"`    | `string` | Partyline nickname             |
+| `"user"`    | `string` | SSH username                   |
+| `"direction"` | `string` | `"inbound"` or `"outbound"` |
+
+## Configuration
+
+```toml
+[logging]
+level = "info"    # error, warn, info, debug
+format = "text"   # text or json
+```
+
+Priority: CLI flag `-log-level` > config file > env `MICELIO_LOG_LEVEL` > default `"info"`.
+
+## Test Assertions
+
+Use the capture helper to verify logging behavior in tests:
+
+```go
+capture := logging.CaptureForTest(t)
+defer capture.Restore()
+
+// ... exercise code ...
+
+if !capture.Has(slog.LevelWarn, "invalid signature") {
+    t.Error("expected warning about invalid signature")
+}
+```
+
+This is preferred over checking stderr output. The capture helper sets log
+level to DEBUG so all messages are visible regardless of global config.
+
+## What NOT to Log
+
+- User-facing terminal output (`fmt.Fprintf` to SSH terminal) is NOT logging.
+- Errors returned to callers — let the caller decide whether to log.
+- Sensitive data (private keys, passwords, full message contents).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,12 @@ type Config struct {
 	Node    NodeConfig    `toml:"node"`
 	SSH     SSHConfig     `toml:"ssh"`
 	Network NetworkConfig `toml:"network"`
+	Logging LoggingConfig `toml:"logging"`
+}
+
+type LoggingConfig struct {
+	Level  string `toml:"level"`  // debug, info, warn, error (default: info)
+	Format string `toml:"format"` // text or json (default: text)
 }
 
 type NodeConfig struct {

--- a/internal/logging/capture.go
+++ b/internal/logging/capture.go
@@ -1,0 +1,106 @@
+package logging
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"sync"
+)
+
+// Capture collects slog records for test assertions.
+// Use CaptureForTest to install it as the global handler.
+type Capture struct {
+	mu        sync.Mutex
+	records   []slog.Record
+	prev      *slog.Logger
+	prevLevel slog.Level
+}
+
+// CaptureForTest installs a capturing handler as the global slog default
+// and returns a Capture that can be queried for assertions.
+// Call Restore() when done (typically via defer).
+func CaptureForTest() *Capture {
+	c := &Capture{
+		prev:      slog.Default(),
+		prevLevel: level.Level(),
+	}
+	handler := &captureHandler{capture: c}
+	slog.SetDefault(slog.New(handler))
+	SetLevel(slog.LevelDebug) // capture everything
+	return c
+}
+
+// Restore reinstates the previous global logger and log level.
+func (c *Capture) Restore() {
+	slog.SetDefault(c.prev)
+	level.Set(c.prevLevel)
+}
+
+// Records returns a copy of all captured records.
+func (c *Capture) Records() []slog.Record {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]slog.Record, len(c.records))
+	copy(out, c.records)
+	return out
+}
+
+// Has returns true if any captured record matches the given level and
+// contains msgSubstring in its message.
+func (c *Capture) Has(level slog.Level, msgSubstring string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, r := range c.records {
+		if r.Level == level && strings.Contains(r.Message, msgSubstring) {
+			return true
+		}
+	}
+	return false
+}
+
+// Count returns the number of captured records at the given level.
+func (c *Capture) Count(level slog.Level) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	n := 0
+	for _, r := range c.records {
+		if r.Level == level {
+			n++
+		}
+	}
+	return n
+}
+
+// captureHandler is a slog.Handler that appends records to a Capture.
+type captureHandler struct {
+	capture *Capture
+	attrs   []slog.Attr
+	group   string
+}
+
+func (h *captureHandler) Enabled(_ context.Context, _ slog.Level) bool {
+	return true
+}
+
+func (h *captureHandler) Handle(_ context.Context, r slog.Record) error {
+	h.capture.mu.Lock()
+	defer h.capture.mu.Unlock()
+	h.capture.records = append(h.capture.records, r)
+	return nil
+}
+
+func (h *captureHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &captureHandler{
+		capture: h.capture,
+		attrs:   append(h.attrs, attrs...),
+		group:   h.group,
+	}
+}
+
+func (h *captureHandler) WithGroup(name string) slog.Handler {
+	return &captureHandler{
+		capture: h.capture,
+		attrs:   h.attrs,
+		group:   name,
+	}
+}

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,0 +1,76 @@
+package logging
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"strings"
+)
+
+var level = new(slog.LevelVar) // supports runtime changes via SetLevel
+
+// Init configures the global slog logger. Call once at startup.
+// levelStr: "debug", "info", "warn", "error" (default: "info").
+// format: "text" or "json" (default: "text").
+func Init(levelStr, format string) {
+	parseLevel(levelStr)
+
+	opts := &slog.HandlerOptions{Level: level}
+	var handler slog.Handler
+	if strings.EqualFold(format, "json") {
+		handler = slog.NewJSONHandler(os.Stderr, opts)
+	} else {
+		handler = slog.NewTextHandler(os.Stderr, opts)
+	}
+	slog.SetDefault(slog.New(handler))
+}
+
+// For returns a logger tagged with the given component name.
+// The returned logger dynamically delegates to slog.Default(), so runtime
+// changes to the global default (e.g., via CaptureForTest) take effect
+// immediately — even for package-level logger variables.
+func For(component string) *slog.Logger {
+	return slog.New(&dynamicHandler{component: component})
+}
+
+// SetLevel changes the log level at runtime. Useful in tests.
+func SetLevel(l slog.Level) {
+	level.Set(l)
+}
+
+func parseLevel(s string) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "debug":
+		level.Set(slog.LevelDebug)
+	case "warn", "warning":
+		level.Set(slog.LevelWarn)
+	case "error":
+		level.Set(slog.LevelError)
+	default:
+		level.Set(slog.LevelInfo)
+	}
+}
+
+// dynamicHandler delegates each log call to slog.Default().Handler(),
+// prepending a "component" attribute. This ensures that package-level loggers
+// created via For() respect runtime changes to the default logger.
+type dynamicHandler struct {
+	component string
+}
+
+func (h *dynamicHandler) Enabled(ctx context.Context, l slog.Level) bool {
+	return slog.Default().Handler().Enabled(ctx, l)
+}
+
+func (h *dynamicHandler) Handle(ctx context.Context, r slog.Record) error {
+	r.AddAttrs(slog.String("component", h.component))
+	return slog.Default().Handler().Handle(ctx, r)
+}
+
+func (h *dynamicHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return h
+}
+
+func (h *dynamicHandler) WithGroup(name string) slog.Handler {
+	return h
+}


### PR DESCRIPTION
## Summary

Replaces all raw `log.Printf` / `log.Fatalf` calls with Go's stdlib `log/slog`, adding leveled output (DEBUG/INFO/WARN/ERROR), per-component tagging, and structured key-value attributes. Adds comprehensive test assertions verifying every log path.

## New: `internal/logging/` package

- **`logging.go`** — thin wrapper around `log/slog`:
  - `Init(level, format)` — configures the global logger once at startup (text or JSON, level from config/CLI/env)
  - `For(component)` — returns `*slog.Logger` tagged with `"component"` attribute; uses a `dynamicHandler` that delegates to `slog.Default().Handler()` on each call, so package-level loggers pick up runtime handler swaps (needed for test capture)
  - `SetLevel(slog.Level)` — runtime level changes (used in tests)

- **`capture.go`** — test helper:
  - `CaptureForTest()` installs a capturing handler as the global slog default, returns `*LogCapture`
  - `Has(level, msgSubstring)` — checks if a record at that level contains the substring
  - `Count(level)` — counts records at a level
  - `Restore()` — restores previous logger and log level (always deferred)

## Configuration

- `internal/config/config.go` — new `LoggingConfig` with `Level` (default `"info"`) and `Format` (default `"text"`) fields, parsed from `[logging]` TOML section
- `cmd/micelio/main.go` — new `-log-level` CLI flag. Priority: CLI flag > config file > `MICELIO_LOG_LEVEL` env var > `"info"`
- `logging.Init()` called early, before any other initialization

## Module-by-module migration

Every `log.Printf` / `log.Fatalf` replaced with structured slog. Each module gets its own component-tagged logger:

| Module | Component tag | Examples |
|--------|--------------|----------|
| `cmd/micelio/main.go` | *(default)* | `slog.Info("node started", "node_id", ...)` |
| `internal/gossip/gossip.go` | `gossip` | WARN dropped/invalid messages, DEBUG received/forwarded/delivered, ERROR marshal failures |
| `internal/transport/manager.go` | `transport` | INFO peer connected/disconnected with `"direction"`, WARN accept errors, DEBUG dial failures |
| `internal/transport/peer.go` | `transport` | WARN full send buffers, ERROR unmarshal failures |
| `internal/transport/discovery.go` | `discovery` | INFO loaded known peers, WARN skipped/invalid peers, DEBUG peer exchange received |
| `internal/ssh/server.go` | `ssh` | INFO client connected, WARN handshake/accept errors |
| `internal/partyline/partyline.go` | `partyline` | DEBUG session joined/left, WARN remote send buffer full |

No raw `"log"` imports remain in `internal/`.

## Test log assertions

Every test file updated with `capture := logging.CaptureForTest()` / `defer capture.Restore()` to assert on expected log output:

- **partyline tests** — 8 tests assert DEBUG "session joined"/"session left"; new `TestRemoteSendBufferFull` covers the WARN "remote send buffer full" path
- **ssh test** — INFO "client connected", DEBUG "session joined"/"session left", zero ERRORs
- **discovery internal tests** — WARN "ignoring peer: mismatched node_id", 6 specific WARNs for invalid stored records, INFO "loaded known peers"
- **manager tests** — INFO "peer connected", zero ERRORs across 3 topology tests
- **discovery integration tests** — INFO "peer connected", DEBUG "received peer exchange", INFO "rejecting inbound: at capacity"
- **gossip integration tests** — INFO "peer connected", DEBUG "message received"/"message forwarded", zero ERRORs

## Logging policy

`.claude/logging-policy.md` documents level definitions, component naming, structured attribute conventions, and test capture patterns.

## Test plan

- [x] `go test -race -timeout 120s ./...` — all pass
- [x] `CGO_ENABLED=0 go build -o /dev/null ./cmd/micelio` — clean build
- [x] No raw `log.Printf` calls remain in `internal/`