### PR TITLE
Align docs with Phase 4 completion

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -26,13 +26,14 @@ From bottom to top:
 
 ## Current Status
 
-The protocol is implemented through Phase 3:
+The protocol is implemented through Phase 4:
 
 - **Phase 1** — Standalone node: identity generation, SSH partyline, bbolt storage.
 - **Phase 2** — Direct connections: Noise-encrypted TCP, protobuf wire protocol, PeerHello handshake, bidirectional chat relay, message signing, deduplication.
 - **Phase 3** — Peer discovery: PeerExchange messages, automatic mesh formation, persistent peer table (bbolt), exponential backoff, MaxPeers enforcement, advertise address support.
+- **Phase 4** — Gossip protocol: multi-hop message relay (fanout=3, max_hops=10), centralized deduplication via seen cache, auto-key-learning from `sender_pubkey`, per-sender rate limiting, trust-level keyring.
 
-Phases 4-7 (gossip relay, distributed state, tagging, plugins) are planned but not yet implemented. Messages currently propagate only to directly connected peers — there is no multi-hop relay.
+Phases 5-7 (distributed state, tagging, plugins) are planned but not yet implemented.
 
 ## Quick Reference
 
@@ -45,4 +46,4 @@ Phases 4-7 (gossip relay, distributed state, tagging, plugins) are planned but n
 | Frame magic | `0x4D49` ("MI") |
 | Max payload | 1 MB |
 | Signature | ED25519 over `message_id ‖ sender_id ‖ lamport_ts ‖ msg_type ‖ payload` |
-| Deduplication | Per-peer seen set, keyed by `message_id`, TTL 5 min |
+| Deduplication | Gossip engine seen cache (`message_id`, TTL 5 min) + per-peer seen set for PeerExchange |

--- a/docs/protocol/messages.md
+++ b/docs/protocol/messages.md
@@ -10,7 +10,7 @@ The `Envelope` is the universal wrapper for every message exchanged between peer
 message Envelope {
     string message_id   = 1;   // UUID v4, unique per message
     string sender_id    = 2;   // node_id of originator
-    uint64 lamport_ts   = 3;   // Lamport clock (reserved, unused in Phase 2)
+    uint64 lamport_ts   = 3;   // Lamport timestamp (included in signatures; currently 0)
     uint32 hop_count    = 4;   // decremented at each hop
     uint32 msg_type     = 5;   // payload type discriminator
     bytes  payload      = 6;   // serialized inner message
@@ -25,7 +25,7 @@ message Envelope {
 |-------|------|-------------|
 | `message_id` | string | UUID v4. Globally unique. Used for deduplication. |
 | `sender_id` | string | Node ID of the originating node (64 hex chars). |
-| `lamport_ts` | uint64 | Lamport timestamp at send time. Reserved for future use (Phase 5). |
+| `lamport_ts` | uint64 | Lamport timestamp. Included in signature computation. Currently set to 0; will carry meaningful values in Phase 5 (distributed state). |
 | `hop_count` | uint32 | TTL decremented at each relay hop. Messages with `hop_count <= 1` are delivered locally but not forwarded. |
 | `msg_type` | uint32 | Discriminator for the `payload` contents. See [Message Types](#message-types). |
 | `payload` | bytes | Serialized inner protobuf message. |
@@ -144,7 +144,7 @@ message ChatMessage {
 
 ## PeerExchange
 
-Carries a list of known reachable peers for automatic mesh formation (Phase 3).
+Carries a list of known reachable peers for automatic mesh formation.
 
 ```protobuf
 message PeerInfo {


### PR DESCRIPTION
## Summary

- **docs/index.md**: Updated "Current Status" from Phase 3 to Phase 4, added Phase 4 bullet (gossip relay, dedup, auto-learn, rate limiting, keyring). Updated deduplication row in Quick Reference to reflect both gossip engine seen cache and per-peer seen sets.
- **docs/protocol/connection.md**: Rewrote "Receive Loop" section to reflect Phase 4 architecture (gossip engine routing for non-direct messages, PeerHello/Ack silently dropped, PeerExchange handled at peer level). Updated "Seen Set Cleanup" to document both dedup levels.
- **docs/protocol/messages.md**: Updated `lamport_ts` description (included in signatures, currently 0, meaningful in Phase 5). Removed "(Phase 3)" from PeerExchange section header.

All other docs (architecture.md, transport.md, identity.md, README.md) were verified accurate — no changes needed. All numeric parameters (fanout, max_hops, TTLs, rates, buffer sizes, intervals) verified against code.

## Test plan

- [x] `mkdocs build --strict` passes with zero warnings