### PR TITLE
Connection health: read deadlines and keepalive

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ bootstrap = [
 max_peers = 15
 exchange_interval = "30s"   # peer exchange period
 discovery_interval = "10s"  # discovery scan period
+
+# Connection health (hardcoded defaults, not yet configurable)
+# idle_timeout = "60s"        # disconnect silent peers after this
+# keepalive_interval = "20s"  # send keepalive when no real traffic
 ```
 
 CLI flags take precedence over config file values.

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,6 +32,7 @@ The protocol is implemented through Phase 4:
 - **Phase 2** — Direct connections: Noise-encrypted TCP, protobuf wire protocol, PeerHello handshake, bidirectional chat relay, message signing, deduplication.
 - **Phase 3** — Peer discovery: PeerExchange messages, automatic mesh formation, persistent peer table (bbolt), exponential backoff, MaxPeers enforcement, advertise address support.
 - **Phase 4** — Gossip protocol: multi-hop message relay (fanout=3, max_hops=10), centralized deduplication via seen cache, auto-key-learning from `sender_pubkey`, per-sender rate limiting, trust-level keyring.
+- **Connection health** — Read deadlines (60s), keepalive messages (20s), write deadlines (10s), and handshake timeout (10s) detect and evict dead or unresponsive peers.
 
 Phases 5-7 (distributed state, tagging, plugins) are planned but not yet implemented.
 
@@ -46,4 +47,8 @@ Phases 5-7 (distributed state, tagging, plugins) are planned but not yet impleme
 | Frame magic | `0x4D49` ("MI") |
 | Max payload | 1 MB |
 | Signature | ED25519 over `message_id ‖ sender_id ‖ lamport_ts ‖ msg_type ‖ payload` |
+| Idle timeout | 60 seconds (read deadline per connection) |
+| Keepalive interval | 20 seconds (suppressed when real traffic flows) |
+| Write timeout | 10 seconds (per-frame write deadline) |
+| Handshake timeout | 10 seconds (PeerHello exchange deadline) |
 | Deduplication | Gossip engine seen cache (`message_id`, TTL 5 min) + per-peer seen set for PeerExchange |

--- a/internal/transport/keepalive_test.go
+++ b/internal/transport/keepalive_test.go
@@ -1,0 +1,225 @@
+package transport_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"micelio/internal/config"
+	"micelio/internal/identity"
+	"micelio/internal/logging"
+	"micelio/internal/partyline"
+	"micelio/internal/transport"
+)
+
+// testPair holds two connected managers for keepalive/timeout tests.
+type testPair struct {
+	MgrA, MgrB       *transport.Manager
+	CancelA, CancelB context.CancelFunc
+	Capture          *logging.Capture
+}
+
+// setupTestPair creates two nodes, connects A→B, and waits for the connection.
+// Each side gets its own idle timeout and keepalive interval.
+// Cleanup is registered via t.Cleanup — callers don't need defer.
+func setupTestPair(t *testing.T, idleA, kaA, idleB, kaB time.Duration) *testPair {
+	t.Helper()
+
+	capture := logging.CaptureForTest()
+
+	dirA, dirB := t.TempDir(), t.TempDir()
+	idA, err := identity.Load(dirA)
+	if err != nil {
+		t.Fatalf("identity A: %v", err)
+	}
+	idB, err := identity.Load(dirB)
+	if err != nil {
+		t.Fatalf("identity B: %v", err)
+	}
+
+	hubA := partyline.NewHub("node-a")
+	hubB := partyline.NewHub("node-b")
+	go hubA.Run()
+	go hubB.Run()
+
+	cfgB := &config.Config{
+		Node:    config.NodeConfig{Name: "node-b", DataDir: dirB},
+		Network: config.NetworkConfig{Listen: "127.0.0.1:0"},
+	}
+	mgrB, err := transport.NewManager(cfgB, idB, hubB, nil)
+	if err != nil {
+		t.Fatalf("manager B: %v", err)
+	}
+	mgrB.SetPeerTimeouts(idleB, kaB)
+
+	ctxB, cancelB := context.WithCancel(context.Background())
+	go mgrB.Start(ctxB)
+
+	deadline := time.Now().Add(5 * time.Second)
+	for mgrB.Addr() == "" && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if mgrB.Addr() == "" {
+		cancelB()
+		t.Fatal("manager B failed to start listener")
+	}
+
+	cfgA := &config.Config{
+		Node: config.NodeConfig{Name: "node-a", DataDir: dirA},
+		Network: config.NetworkConfig{
+			Listen:    "127.0.0.1:0",
+			Bootstrap: []string{mgrB.Addr()},
+		},
+	}
+	mgrA, err := transport.NewManager(cfgA, idA, hubA, nil)
+	if err != nil {
+		cancelB()
+		t.Fatalf("manager A: %v", err)
+	}
+	mgrA.SetPeerTimeouts(idleA, kaA)
+
+	ctxA, cancelA := context.WithCancel(context.Background())
+	go mgrA.Start(ctxA)
+
+	// Wait for connection.
+	deadline = time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if mgrA.PeerCount() > 0 && mgrB.PeerCount() > 0 {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if mgrA.PeerCount() == 0 || mgrB.PeerCount() == 0 {
+		cancelA()
+		cancelB()
+		t.Fatalf("peers not connected: A=%d B=%d", mgrA.PeerCount(), mgrB.PeerCount())
+	}
+
+	tp := &testPair{
+		MgrA: mgrA, MgrB: mgrB,
+		CancelA: cancelA, CancelB: cancelB,
+		Capture: capture,
+	}
+	t.Cleanup(func() {
+		cancelA()
+		cancelB()
+		mgrA.Stop()
+		mgrB.Stop()
+		hubA.Stop()
+		hubB.Stop()
+		capture.Restore()
+	})
+
+	return tp
+}
+
+// TestKeepalivePreventTimeout verifies that idle connections stay alive when
+// keepalives are active. Two nodes are connected with short timeouts. No chat
+// messages are exchanged. After waiting well beyond the idle timeout, both
+// nodes should still be connected because keepalives reset the read deadline.
+func TestKeepalivePreventTimeout(t *testing.T) {
+	tp := setupTestPair(t,
+		2*time.Second, 500*time.Millisecond, // A: 2s idle, 500ms keepalive
+		2*time.Second, 500*time.Millisecond, // B: 2s idle, 500ms keepalive
+	)
+
+	// Wait 3x the idle timeout — keepalives should keep the connection alive.
+	// PeerExchange (default interval 30s) cannot interfere here because the
+	// idle timeout is only 2s, so keepalives (500ms) are the sole mechanism
+	// resetting the read deadline.
+	time.Sleep(6 * time.Second)
+
+	if tp.MgrA.PeerCount() == 0 {
+		t.Error("node A lost connection despite keepalives")
+	}
+	if tp.MgrB.PeerCount() == 0 {
+		t.Error("node B lost connection despite keepalives")
+	}
+
+	if !tp.Capture.Has(slog.LevelInfo, "peer connected") {
+		t.Error("expected INFO log: peer connected")
+	}
+	// No idle timeout warnings should appear — keepalives prevent them.
+	if tp.Capture.Has(slog.LevelWarn, "peer idle timeout") {
+		t.Error("unexpected WARN: peer idle timeout (keepalives should prevent this)")
+	}
+	if tp.Capture.Count(slog.LevelError) != 0 {
+		t.Errorf("unexpected ERROR logs: %d", tp.Capture.Count(slog.LevelError))
+	}
+}
+
+// TestIdleTimeout verifies that a silent peer is disconnected after the idle
+// timeout. Node A connects to node B with a very long keepalive interval (1h),
+// effectively disabling keepalives. Node B should disconnect A because no data
+// arrives from A within the idle timeout.
+func TestIdleTimeout(t *testing.T) {
+	tp := setupTestPair(t,
+		2*time.Second, 1*time.Hour, // A: 2s idle, no keepalive (1h)
+		2*time.Second, 500*time.Millisecond, // B: 2s idle, 500ms keepalive
+	)
+
+	// Cancel A's context so dialWithBackoff stops reconnecting after B
+	// disconnects A. Without this, A would reconnect immediately and reset
+	// B's read deadline with a fresh PeerHello, preventing the idle timeout.
+	tp.CancelA()
+
+	// Wait for B to detect A's silence and disconnect.
+	// B has idleTimeout=2s and A sends no keepalives.
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if tp.MgrB.PeerCount() == 0 {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	if tp.MgrB.PeerCount() != 0 {
+		t.Fatal("node B should have disconnected silent peer A")
+	}
+
+	if !tp.Capture.Has(slog.LevelInfo, "peer connected") {
+		t.Error("expected INFO log: peer connected")
+	}
+	if !tp.Capture.Has(slog.LevelWarn, "peer idle timeout") {
+		t.Error("expected WARN log: peer idle timeout")
+	}
+	if !tp.Capture.Has(slog.LevelInfo, "peer disconnected") {
+		t.Error("expected INFO log: peer disconnected")
+	}
+}
+
+// TestWriteTimeout verifies that a peer is disconnected when writes time out.
+// After connecting normally, node A's write timeout is set to 1ns, making any
+// subsequent write deadline expire before the write completes. The next
+// keepalive write should fail with a timeout, triggering disconnection.
+func TestWriteTimeout(t *testing.T) {
+	tp := setupTestPair(t,
+		10*time.Second, 200*time.Millisecond, // A: long idle, fast keepalive
+		10*time.Second, 200*time.Millisecond, // B: long idle, fast keepalive
+	)
+
+	// After connection is established, set A's write timeout to 1ns.
+	// The next keepalive write will hit the deadline immediately.
+	tp.MgrA.SetPeerWriteTimeout(time.Nanosecond)
+
+	// Wait for A to fail on the next write.
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if tp.MgrA.PeerCount() == 0 {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	if tp.MgrA.PeerCount() != 0 {
+		t.Fatal("node A should have disconnected after write timeout")
+	}
+
+	if !tp.Capture.Has(slog.LevelWarn, "peer write timeout") {
+		t.Error("expected WARN log: peer write timeout")
+	}
+	if !tp.Capture.Has(slog.LevelInfo, "peer disconnected") {
+		t.Error("expected INFO log: peer disconnected")
+	}
+}

--- a/internal/transport/noise.go
+++ b/internal/transport/noise.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net"
 	"sync"
+	"time"
 
 	"github.com/flynn/noise"
 )
@@ -172,6 +173,21 @@ func (nc *noiseConn) Read(p []byte) (int, error) {
 		nc.readBuf = plaintext[n:]
 	}
 	return n, nil
+}
+
+// SetReadDeadline sets the read deadline on the underlying TCP connection.
+//
+// The deadline only applies when readBuf is empty, i.e. when Read would
+// block on the TCP socket. For peers that use WriteFrame as implemented
+// here (one complete frame per Write call), each Noise message carries
+// exactly one frame, so readBuf is normally empty between ReadFrame calls.
+func (nc *noiseConn) SetReadDeadline(t time.Time) error {
+	return nc.conn.SetReadDeadline(t)
+}
+
+// SetWriteDeadline sets the write deadline on the underlying TCP connection.
+func (nc *noiseConn) SetWriteDeadline(t time.Time) error {
+	return nc.conn.SetWriteDeadline(t)
 }
 
 // Close closes the underlying connection.


### PR DESCRIPTION
Closes #16

## Summary

Peer connections previously had no read timeout. If a peer went silent (crash, network partition, zombie process), `recvLoop` blocked forever on `ReadFrame()` → `io.ReadFull()`, permanently occupying a peer slot and silently degrading the mesh.

This PR adds two complementary mechanisms:

### Read deadlines

- `recvLoop` sets a 60-second read deadline (`SetReadDeadline`) on the underlying TCP connection before each `ReadFrame` call
- On deadline exceeded, the peer is disconnected with a WARN log `"peer idle timeout"`
- Timeout detection uses `errors.As(err, &net.Error)` to unwrap through `ReadFrame`'s error wrapping

### Keepalive

- `sendLoop` sends a lightweight keepalive frame (`MsgTypeKeepalive = 5`) every 20 seconds if no other message was sent in that window
- The keepalive is a minimal protobuf `Envelope` with only `msg_type=5` set — no signature needed since the Noise-encrypted channel guarantees integrity
- `recvLoop` silently drops keepalive frames (no gossip routing, no handler dispatch)
- The keepalive ticker resets on every real message send, avoiding redundant traffic during active communication

### Configurability

- `Peer` struct has `idleTimeout` and `keepaliveInterval` fields (defaults: 60s, 20s)
- `Manager.SetPeerTimeouts(idle, keepalive)` allows overriding before `Start()` — used in tests for fast timeouts
- `noiseConn.SetReadDeadline()` delegates to the underlying `net.Conn`

## Files changed

| File | Change |
|------|--------|
| `internal/transport/peer.go` | `MsgTypeKeepalive` constant, configurable timeout fields, read deadline in `recvLoop`, keepalive ticker in `sendLoop`, `writeKeepalive()`, timeout detection with `errors.As` |
| `internal/transport/noise.go` | `SetReadDeadline` method on `noiseConn` |
| `internal/transport/manager.go` | `SetPeerTimeouts()` public method, `applyPeerTimeouts()` helper, timeout fields on Manager |
| `internal/transport/keepalive_test.go` | Two integration tests |

## Tests

- **TestKeepalivePreventTimeout**: Two nodes with 2s idle timeout and 500ms keepalive. No chat messages exchanged. After 6s (3x idle timeout), both nodes remain connected. Asserts: `peer connected` (INFO), no `peer idle timeout` (WARN), no ERROR logs.
- **TestIdleTimeout**: Node A has keepalive disabled (1h interval), node B has 2s idle timeout. B detects A's silence and disconnects. Asserts: `peer connected` (INFO), `peer idle timeout` (WARN), `peer disconnected` (INFO).

## Test plan

- [x] `go test -race -timeout 120s ./...` — all pass
- [x] `CGO_ENABLED=0 go build -o /dev/null ./cmd/micelio` — clean