### PR TITLE
Fix GitHub workflows configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,11 @@
 version: 2
 updates:
   - package-ecosystem: "gomod"
-      directory: "/"
-          schedule:
-                interval: "weekly"
-                    allow:
-                          - dependency-type: "all"
-                              open-pull-requests-limit: 10
-                                  reviewers:
-                                        - "gdassori"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    allow:
+      - dependency-type: "all"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "gdassori"


### PR DESCRIPTION
## Summary
Fixes two configuration issues in GitHub workflows:

1. **docs.yml**: Move permissions from workflow level to job level following principle of least privilege
   - Build job: `contents: read`
   - Deploy job: `pages: write`, `id-token: write`

2. **dependabot.yml**: Fix YAML syntax error
   - Corrected progressive 4-space indentation to proper 2-space YAML structure
   - Resolves parsing error at line 3, column 5

## Test plan
- ✅ Dependabot workflow should pass validation
- ✅ Docs workflow permissions scoped correctly per job