### PR TITLE
Phase 5: Distributed state map with per-entry auth and delta sync

### DIFF
--- a/cmd/micelio/main.go
+++ b/cmd/micelio/main.go
@@ -135,7 +135,7 @@ func main() {
 
 	// Register state commands if transport manager has a state map.
 	if mgr != nil {
-		registerStateCommands(sshServer.Commands(), mgr.StateMap())
+		registerStateCommands(sshServer.Commands(), mgr.StateMap(), id.NodeID)
 	}
 
 	go func() {

--- a/cmd/micelio/main.go
+++ b/cmd/micelio/main.go
@@ -133,6 +133,11 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Register state commands if transport manager has a state map.
+	if mgr != nil {
+		registerStateCommands(sshServer.Commands(), mgr.StateMap())
+	}
+
 	go func() {
 		if err := sshServer.Start(ctx); err != nil {
 			slog.Error("fatal: ssh", "err", err)

--- a/cmd/micelio/state_commands.go
+++ b/cmd/micelio/state_commands.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"micelio/internal/ssh"
+	"micelio/internal/state"
+)
+
+func registerStateCommands(reg ssh.CommandRegistrar, stateMap *state.Map) {
+	if stateMap == nil {
+		return
+	}
+
+	reg.Register("/state", ssh.Command{
+		Help: "display all state entries",
+		Handler: func(ctx ssh.CommandContext) bool {
+			entries := stateMap.Snapshot()
+			if len(entries) == 0 {
+				_, _ = fmt.Fprintln(ctx.Terminal, "State: (empty)")
+				return false
+			}
+			sort.Slice(entries, func(i, j int) bool {
+				return entries[i].Key < entries[j].Key
+			})
+			_, _ = fmt.Fprintf(ctx.Terminal, "State (%d entries):\r\n", len(entries))
+			for _, e := range entries {
+				nodeShort := e.NodeID
+				if len(nodeShort) > 12 {
+					nodeShort = nodeShort[:12]
+				}
+				_, _ = fmt.Fprintf(ctx.Terminal, "  %-20s = %s  (ts=%d node=%s)\r\n",
+					e.Key, string(e.Value), e.LamportTs, nodeShort)
+			}
+			return false
+		},
+	})
+
+	reg.Register("/set", ssh.Command{
+		Usage: "/set <key> <value>",
+		Help:  "set a state entry (propagates via gossip)",
+		Handler: func(ctx ssh.CommandContext) bool {
+			if len(ctx.Args) < 2 {
+				_, _ = fmt.Fprintln(ctx.Terminal, "Usage: /set <key> <value>")
+				return false
+			}
+			key := ctx.Args[0]
+			value := strings.Join(ctx.Args[1:], " ")
+			entry, accepted, err := stateMap.Set(key, []byte(value))
+			if err != nil {
+				_, _ = fmt.Fprintf(ctx.Terminal, "Error: %v\r\n", err)
+			} else if accepted {
+				_, _ = fmt.Fprintf(ctx.Terminal, "Set %s = %s (ts=%d)\r\n", key, value, entry.LamportTs)
+			} else {
+				_, _ = fmt.Fprintln(ctx.Terminal, "Set rejected (stale clock)")
+			}
+			return false
+		},
+	})
+
+	reg.Register("/get", ssh.Command{
+		Usage: "/get <key>",
+		Help:  "get a state entry",
+		Handler: func(ctx ssh.CommandContext) bool {
+			if len(ctx.Args) == 0 {
+				_, _ = fmt.Fprintln(ctx.Terminal, "Usage: /get <key>")
+				return false
+			}
+			key := ctx.Args[0]
+			entry, ok := stateMap.Get(key)
+			if !ok {
+				_, _ = fmt.Fprintf(ctx.Terminal, "%s: not found\r\n", key)
+				return false
+			}
+			nodeShort := entry.NodeID
+			if len(nodeShort) > 12 {
+				nodeShort = nodeShort[:12]
+			}
+			_, _ = fmt.Fprintf(ctx.Terminal, "%s = %s  (ts=%d node=%s)\r\n",
+				key, string(entry.Value), entry.LamportTs, nodeShort)
+			return false
+		},
+	})
+}

--- a/cmd/micelio/state_commands.go
+++ b/cmd/micelio/state_commands.go
@@ -15,103 +15,117 @@ func registerStateCommands(reg ssh.CommandRegistrar, stateMap *state.Map, localN
 	}
 
 	reg.Register("/state", ssh.Command{
-		Help: "display all state entries",
-		Handler: func(ctx ssh.CommandContext) bool {
-			entries := stateMap.Snapshot()
-			// Filter out tombstones for display.
-			active := entries[:0]
-			for _, e := range entries {
-				if !e.Deleted {
-					active = append(active, e)
-				}
-			}
-			if len(active) == 0 {
-				_, _ = fmt.Fprintln(ctx.Terminal, "State: (empty)")
-				return false
-			}
-			sort.Slice(active, func(i, j int) bool {
-				return active[i].Key < active[j].Key
-			})
-			_, _ = fmt.Fprintf(ctx.Terminal, "State (%d entries):\r\n", len(active))
-			for _, e := range active {
-				nodeShort := e.NodeID
-				if len(nodeShort) > 12 {
-					nodeShort = nodeShort[:12]
-				}
-				_, _ = fmt.Fprintf(ctx.Terminal, "  %-20s = %s  (ts=%d node=%s)\r\n",
-					e.Key, string(e.Value), e.LamportTs, nodeShort)
-			}
-			return false
-		},
+		Help:    "display all state entries",
+		Handler: handleState(stateMap),
 	})
 
 	reg.Register("/set", ssh.Command{
-		Usage: "/set <key> <value>",
-		Help:  "set a state entry (propagates via gossip)",
-		Handler: func(ctx ssh.CommandContext) bool {
-			if len(ctx.Args) < 2 {
-				_, _ = fmt.Fprintln(ctx.Terminal, "Usage: /set <key> <value>")
-				return false
-			}
-			key := ctx.Args[0]
-			value := strings.Join(ctx.Args[1:], " ")
-			entry, accepted, err := stateMap.Set(key, []byte(value))
-			if err != nil {
-				_, _ = fmt.Fprintf(ctx.Terminal, "Error: %v\r\n", err)
-			} else if accepted {
-				_, _ = fmt.Fprintf(ctx.Terminal, "Set %s = %s (ts=%d)\r\n", key, value, entry.LamportTs)
-			} else {
-				_, _ = fmt.Fprintln(ctx.Terminal, "Set rejected (stale clock)")
-			}
-			return false
-		},
+		Usage:   "/set <key> <value>",
+		Help:    "set a state entry (propagates via gossip)",
+		Handler: handleSet(stateMap),
 	})
 
 	reg.Register("/del", ssh.Command{
-		Usage: "/del <key>",
-		Help:  "delete a state entry (propagates via gossip)",
-		Handler: func(ctx ssh.CommandContext) bool {
-			if len(ctx.Args) == 0 {
-				_, _ = fmt.Fprintln(ctx.Terminal, "Usage: /del <key>")
-				return false
-			}
-			key := ctx.Args[0]
-			entry, accepted, err := stateMap.Delete(key)
-			if err != nil {
-				_, _ = fmt.Fprintf(ctx.Terminal, "Error: %v\r\n", err)
-			} else if accepted {
-				_, _ = fmt.Fprintf(ctx.Terminal, "Deleted %s (ts=%d)\r\n", key, entry.LamportTs)
-			} else {
-				_, _ = fmt.Fprintln(ctx.Terminal, "Delete rejected (stale clock)")
-			}
-			return false
-		},
+		Usage:   "/del <key>",
+		Help:    "delete a state entry (propagates via gossip)",
+		Handler: handleDel(stateMap),
 	})
 
 	reg.Register("/get", ssh.Command{
-		Usage: "/get <key>",
-		Help:  "get a state entry (plain key = own namespace, key with / = full key)",
-		Handler: func(ctx ssh.CommandContext) bool {
-			if len(ctx.Args) == 0 {
-				_, _ = fmt.Fprintln(ctx.Terminal, "Usage: /get <key>")
-				return false
-			}
-			key := ctx.Args[0]
-			if !strings.Contains(key, "/") {
-				key = localNodeID + "/" + key
-			}
-			entry, ok := stateMap.Get(key)
-			if !ok {
-				_, _ = fmt.Fprintf(ctx.Terminal, "%s: not found\r\n", key)
-				return false
-			}
-			nodeShort := entry.NodeID
-			if len(nodeShort) > 12 {
-				nodeShort = nodeShort[:12]
-			}
-			_, _ = fmt.Fprintf(ctx.Terminal, "%s = %s  (ts=%d node=%s)\r\n",
-				key, string(entry.Value), entry.LamportTs, nodeShort)
-			return false
-		},
+		Usage:   "/get <key>",
+		Help:    "get a state entry (plain key = own namespace, key with / = full key)",
+		Handler: handleGet(stateMap, localNodeID),
 	})
+}
+
+func handleState(stateMap *state.Map) func(ssh.CommandContext) bool {
+	return func(ctx ssh.CommandContext) bool {
+		entries := stateMap.Snapshot()
+		active := entries[:0]
+		for _, e := range entries {
+			if !e.Deleted {
+				active = append(active, e)
+			}
+		}
+		if len(active) == 0 {
+			_, _ = fmt.Fprintln(ctx.Terminal, "State: (empty)")
+			return false
+		}
+		sort.Slice(active, func(i, j int) bool {
+			return active[i].Key < active[j].Key
+		})
+		_, _ = fmt.Fprintf(ctx.Terminal, "State (%d entries):\r\n", len(active))
+		for _, e := range active {
+			_, _ = fmt.Fprintf(ctx.Terminal, "  %-20s = %s  (ts=%d node=%s)\r\n",
+				e.Key, string(e.Value), e.LamportTs, shortNodeID(e.NodeID))
+		}
+		return false
+	}
+}
+
+func handleSet(stateMap *state.Map) func(ssh.CommandContext) bool {
+	return func(ctx ssh.CommandContext) bool {
+		if len(ctx.Args) < 2 {
+			_, _ = fmt.Fprintln(ctx.Terminal, "Usage: /set <key> <value>")
+			return false
+		}
+		key := ctx.Args[0]
+		value := strings.Join(ctx.Args[1:], " ")
+		entry, accepted, err := stateMap.Set(key, []byte(value))
+		if err != nil {
+			_, _ = fmt.Fprintf(ctx.Terminal, "Error: %v\r\n", err)
+		} else if accepted {
+			_, _ = fmt.Fprintf(ctx.Terminal, "Set %s = %s (ts=%d)\r\n", key, value, entry.LamportTs)
+		} else {
+			_, _ = fmt.Fprintln(ctx.Terminal, "Set rejected (stale clock)")
+		}
+		return false
+	}
+}
+
+func handleDel(stateMap *state.Map) func(ssh.CommandContext) bool {
+	return func(ctx ssh.CommandContext) bool {
+		if len(ctx.Args) == 0 {
+			_, _ = fmt.Fprintln(ctx.Terminal, "Usage: /del <key>")
+			return false
+		}
+		key := ctx.Args[0]
+		entry, accepted, err := stateMap.Delete(key)
+		if err != nil {
+			_, _ = fmt.Fprintf(ctx.Terminal, "Error: %v\r\n", err)
+		} else if accepted {
+			_, _ = fmt.Fprintf(ctx.Terminal, "Deleted %s (ts=%d)\r\n", key, entry.LamportTs)
+		} else {
+			_, _ = fmt.Fprintln(ctx.Terminal, "Delete rejected (stale clock)")
+		}
+		return false
+	}
+}
+
+func handleGet(stateMap *state.Map, localNodeID string) func(ssh.CommandContext) bool {
+	return func(ctx ssh.CommandContext) bool {
+		if len(ctx.Args) == 0 {
+			_, _ = fmt.Fprintln(ctx.Terminal, "Usage: /get <key>")
+			return false
+		}
+		key := ctx.Args[0]
+		if !strings.Contains(key, "/") {
+			key = localNodeID + "/" + key
+		}
+		entry, ok := stateMap.Get(key)
+		if !ok {
+			_, _ = fmt.Fprintf(ctx.Terminal, "%s: not found\r\n", key)
+			return false
+		}
+		_, _ = fmt.Fprintf(ctx.Terminal, "%s = %s  (ts=%d node=%s)\r\n",
+			key, string(entry.Value), entry.LamportTs, shortNodeID(entry.NodeID))
+		return false
+	}
+}
+
+func shortNodeID(id string) string {
+	if len(id) > 12 {
+		return id[:12]
+	}
+	return id
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,6 +31,7 @@ type Config struct {
 	SSH     SSHConfig     `toml:"ssh"`
 	Network NetworkConfig `toml:"network"`
 	Logging LoggingConfig `toml:"logging"`
+	State   StateConfig   `toml:"state"`
 }
 
 type LoggingConfig struct {
@@ -57,6 +58,11 @@ type NetworkConfig struct {
 	DiscoveryInterval Duration `toml:"discovery_interval"` // discovery scan period; 0 → 10s default
 }
 
+type StateConfig struct {
+	TombstoneTTL Duration `toml:"tombstone_ttl"` // how long tombstones live before GC; 0 → 24h default
+	GCInterval   Duration `toml:"gc_interval"`   // GC scan period; 0 → 1h default
+}
+
 // Defaults returns a Config with sane defaults.
 func Defaults() *Config {
 	hostname, _ := os.Hostname()
@@ -75,6 +81,10 @@ func Defaults() *Config {
 			MaxPeers:          15,
 			ExchangeInterval:  Duration{30 * time.Second},
 			DiscoveryInterval: Duration{10 * time.Second},
+		},
+		State: StateConfig{
+			TombstoneTTL: Duration{24 * time.Hour},
+			GCInterval:   Duration{1 * time.Hour},
 		},
 	}
 }

--- a/internal/state/auth.go
+++ b/internal/state/auth.go
@@ -1,0 +1,58 @@
+package state
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"strings"
+)
+
+// SignEntry signs an entry with the given private key and embeds the public key.
+// The signature covers all semantic fields: key, value, lamport_ts, node_id, deleted.
+func SignEntry(e *Entry, privKey ed25519.PrivateKey) {
+	e.AuthorPubkey = privKey.Public().(ed25519.PublicKey)
+	e.Signature = ed25519.Sign(privKey, entrySignData(*e))
+}
+
+// VerifyEntry checks that an entry is authentic and authorized:
+//  1. AuthorPubkey is a valid 32-byte ED25519 public key
+//  2. sha256(AuthorPubkey) == NodeID (pubkey matches claimed identity)
+//  3. Key starts with NodeID + "/" (author owns the namespace)
+//  4. ED25519 signature is valid over the semantic fields
+//
+// Returns true if all checks pass. Callers should reject entries that fail.
+func VerifyEntry(e Entry) bool {
+	if len(e.AuthorPubkey) != ed25519.PublicKeySize {
+		return false
+	}
+
+	hash := sha256.Sum256(e.AuthorPubkey)
+	if hex.EncodeToString(hash[:]) != e.NodeID {
+		return false
+	}
+
+	if !strings.HasPrefix(e.Key, e.NodeID+"/") {
+		return false
+	}
+
+	return ed25519.Verify(e.AuthorPubkey, entrySignData(e), e.Signature)
+}
+
+// entrySignData returns the canonical byte representation for signing/verification.
+// Format: key (utf8) || value (raw) || lamport_ts (uint64 BE) || node_id (utf8) || deleted (1 byte)
+func entrySignData(e Entry) []byte {
+	var buf []byte
+	buf = append(buf, []byte(e.Key)...)
+	buf = append(buf, e.Value...)
+	var ts [8]byte
+	binary.BigEndian.PutUint64(ts[:], e.LamportTs)
+	buf = append(buf, ts[:]...)
+	buf = append(buf, []byte(e.NodeID)...)
+	if e.Deleted {
+		buf = append(buf, 1)
+	} else {
+		buf = append(buf, 0)
+	}
+	return buf
+}

--- a/internal/state/auth_test.go
+++ b/internal/state/auth_test.go
@@ -1,0 +1,120 @@
+package state
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+)
+
+func makeTestEntry(t *testing.T) (Entry, ed25519.PrivateKey) {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pub := priv.Public().(ed25519.PublicKey)
+	hash := sha256.Sum256(pub)
+	nodeID := hex.EncodeToString(hash[:])
+
+	e := Entry{
+		Key:       nodeID + "/name",
+		Value:     []byte("my-node"),
+		LamportTs: 42,
+		NodeID:    nodeID,
+	}
+	SignEntry(&e, priv)
+	return e, priv
+}
+
+func TestSignAndVerifyEntry(t *testing.T) {
+	e, _ := makeTestEntry(t)
+
+	if !VerifyEntry(e) {
+		t.Fatal("valid signed entry should verify")
+	}
+	if len(e.Signature) != ed25519.SignatureSize {
+		t.Fatalf("Signature len = %d, want %d", len(e.Signature), ed25519.SignatureSize)
+	}
+	if len(e.AuthorPubkey) != ed25519.PublicKeySize {
+		t.Fatalf("AuthorPubkey len = %d, want %d", len(e.AuthorPubkey), ed25519.PublicKeySize)
+	}
+}
+
+func TestVerifyEntryBadSignature(t *testing.T) {
+	e, _ := makeTestEntry(t)
+
+	// Corrupt signature
+	e.Signature[0] ^= 0xff
+	if VerifyEntry(e) {
+		t.Fatal("corrupted signature should not verify")
+	}
+}
+
+func TestVerifyEntryWrongNamespace(t *testing.T) {
+	_, priv, _ := ed25519.GenerateKey(nil)
+	pub := priv.Public().(ed25519.PublicKey)
+	hash := sha256.Sum256(pub)
+	nodeID := hex.EncodeToString(hash[:])
+
+	e := Entry{
+		Key:       "wrong-prefix/name",
+		Value:     []byte("val"),
+		LamportTs: 1,
+		NodeID:    nodeID,
+	}
+	SignEntry(&e, priv)
+
+	if VerifyEntry(e) {
+		t.Fatal("entry with wrong namespace should not verify")
+	}
+}
+
+func TestVerifyEntryPubkeyMismatch(t *testing.T) {
+	e, _ := makeTestEntry(t)
+
+	// Replace pubkey with a different one (nodeID won't match)
+	_, otherPriv, _ := ed25519.GenerateKey(nil)
+	otherPub := otherPriv.Public().(ed25519.PublicKey)
+	e.AuthorPubkey = otherPub
+
+	if VerifyEntry(e) {
+		t.Fatal("entry with mismatched pubkey should not verify")
+	}
+}
+
+func TestVerifyEntryMissingPubkey(t *testing.T) {
+	e, _ := makeTestEntry(t)
+	e.AuthorPubkey = nil
+
+	if VerifyEntry(e) {
+		t.Fatal("entry with nil pubkey should not verify")
+	}
+}
+
+func TestVerifyEntryTamperedValue(t *testing.T) {
+	e, _ := makeTestEntry(t)
+	e.Value = []byte("tampered")
+
+	if VerifyEntry(e) {
+		t.Fatal("entry with tampered value should not verify")
+	}
+}
+
+func TestVerifyEntryTamperedTimestamp(t *testing.T) {
+	e, _ := makeTestEntry(t)
+	e.LamportTs = 999
+
+	if VerifyEntry(e) {
+		t.Fatal("entry with tampered timestamp should not verify")
+	}
+}
+
+func TestVerifyEntryTamperedDeleted(t *testing.T) {
+	e, _ := makeTestEntry(t)
+	e.Deleted = true
+
+	if VerifyEntry(e) {
+		t.Fatal("entry with tampered deleted flag should not verify")
+	}
+}

--- a/internal/state/lamport.go
+++ b/internal/state/lamport.go
@@ -1,0 +1,51 @@
+package state
+
+import "sync/atomic"
+
+// LamportClock is a monotonically increasing logical clock.
+// It is safe for concurrent use.
+type LamportClock struct {
+	counter atomic.Uint64
+}
+
+// Tick increments the clock and returns the new value.
+// Used when generating a new local event (e.g., /set command).
+func (c *LamportClock) Tick() uint64 {
+	return c.counter.Add(1)
+}
+
+// Witness updates the clock to be at least the observed value,
+// then ticks. Returns the new value.
+// Used when receiving a remote state entry.
+func (c *LamportClock) Witness(observed uint64) uint64 {
+	for {
+		current := c.counter.Load()
+		next := current
+		if observed > next {
+			next = observed
+		}
+		next++
+		if c.counter.CompareAndSwap(current, next) {
+			return next
+		}
+	}
+}
+
+// Current returns the current clock value without incrementing.
+func (c *LamportClock) Current() uint64 {
+	return c.counter.Load()
+}
+
+// SetFloor ensures the clock is at least floor. Does NOT tick.
+// Used during startup to restore from persisted state.
+func (c *LamportClock) SetFloor(floor uint64) {
+	for {
+		current := c.counter.Load()
+		if current >= floor {
+			return
+		}
+		if c.counter.CompareAndSwap(current, floor) {
+			return
+		}
+	}
+}

--- a/internal/state/lamport_test.go
+++ b/internal/state/lamport_test.go
@@ -1,0 +1,79 @@
+package state
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestLamportTick(t *testing.T) {
+	var c LamportClock
+	for i := uint64(1); i <= 10; i++ {
+		if got := c.Tick(); got != i {
+			t.Fatalf("Tick() = %d, want %d", got, i)
+		}
+	}
+}
+
+func TestLamportWitnessHigher(t *testing.T) {
+	var c LamportClock
+	c.Tick() // counter = 1
+
+	got := c.Witness(100)
+	if got != 101 {
+		t.Fatalf("Witness(100) = %d, want 101", got)
+	}
+	if c.Current() != 101 {
+		t.Fatalf("Current() = %d, want 101", c.Current())
+	}
+}
+
+func TestLamportWitnessLower(t *testing.T) {
+	var c LamportClock
+	for i := 0; i < 10; i++ {
+		c.Tick() // counter = 10
+	}
+
+	got := c.Witness(5) // observed < current, still ticks
+	if got != 11 {
+		t.Fatalf("Witness(5) = %d, want 11", got)
+	}
+}
+
+func TestLamportSetFloor(t *testing.T) {
+	var c LamportClock
+	c.SetFloor(50)
+	if c.Current() != 50 {
+		t.Fatalf("Current() = %d, want 50", c.Current())
+	}
+
+	// SetFloor with lower value is a no-op
+	c.SetFloor(10)
+	if c.Current() != 50 {
+		t.Fatalf("Current() = %d, want 50 after lower SetFloor", c.Current())
+	}
+}
+
+func TestLamportConcurrent(t *testing.T) {
+	var c LamportClock
+	var wg sync.WaitGroup
+	n := 100
+
+	wg.Add(n * 2)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			c.Tick()
+		}()
+		go func(v uint64) {
+			defer wg.Done()
+			c.Witness(v)
+		}(uint64(i))
+	}
+	wg.Wait()
+
+	// After n Ticks and n Witnesses, counter must be at least n
+	// (each Tick adds 1, each Witness adds at least 1).
+	if c.Current() < uint64(n) {
+		t.Fatalf("Current() = %d, want >= %d", c.Current(), n)
+	}
+}

--- a/internal/state/map.go
+++ b/internal/state/map.go
@@ -1,0 +1,160 @@
+package state
+
+import (
+	"errors"
+	"sync"
+
+	"micelio/internal/logging"
+)
+
+// Limits to prevent resource exhaustion from malicious peers.
+const (
+	MaxKeyLen        = 256        // max key length in bytes
+	MaxValueLen      = 4096       // max value length in bytes
+	MaxStateEntries  = 10_000     // max entries in the state map
+	MaxSafeLamportTs = 1 << 62   // reject timestamps above this to prevent clock poisoning
+)
+
+var (
+	ErrKeyTooLong   = errors.New("key exceeds max length")
+	ErrValueTooLong = errors.New("value exceeds max length")
+	ErrMapFull      = errors.New("state map at capacity")
+	ErrTsOverflow   = errors.New("lamport timestamp exceeds safe maximum")
+)
+
+var logger = logging.For("state")
+
+// Entry is a single state entry with LWW metadata.
+type Entry struct {
+	Key       string
+	Value     []byte
+	LamportTs uint64
+	NodeID    string
+}
+
+// Wins returns true if this entry wins over other according to LWW rules:
+// higher lamport_ts wins; on tie, lexicographically greater node_id wins.
+func (e Entry) Wins(other Entry) bool {
+	if e.LamportTs != other.LamportTs {
+		return e.LamportTs > other.LamportTs
+	}
+	return e.NodeID > other.NodeID
+}
+
+// ChangeHandler is called when a local state entry is accepted (wins LWW).
+// Used by the transport layer to broadcast state updates via gossip.
+type ChangeHandler func(entry Entry)
+
+// Map is a thread-safe in-memory LWW state map.
+type Map struct {
+	mu       sync.RWMutex
+	entries  map[string]Entry
+	clock    *LamportClock
+	localID  string
+	onChange ChangeHandler
+}
+
+// NewMap creates a new state map for the given local node ID.
+func NewMap(localID string) *Map {
+	return &Map{
+		entries: make(map[string]Entry),
+		clock:   &LamportClock{},
+		localID: localID,
+	}
+}
+
+// SetChangeHandler sets the callback invoked when a local Set wins LWW.
+// Must be called before any concurrent access.
+func (m *Map) SetChangeHandler(h ChangeHandler) {
+	m.onChange = h
+}
+
+// Clock returns the map's Lamport clock.
+func (m *Map) Clock() *LamportClock {
+	return m.clock
+}
+
+// Set creates or updates a local entry. Ticks the Lamport clock,
+// applies LWW, and if the write wins, calls the change handler.
+// Returns an error if key or value exceeds size limits.
+func (m *Map) Set(key string, value []byte) (Entry, bool, error) {
+	if len(key) > MaxKeyLen {
+		return Entry{}, false, ErrKeyTooLong
+	}
+	if len(value) > MaxValueLen {
+		return Entry{}, false, ErrValueTooLong
+	}
+	ts := m.clock.Tick()
+	entry := Entry{
+		Key:       key,
+		Value:     value,
+		LamportTs: ts,
+		NodeID:    m.localID,
+	}
+	return entry, m.merge(entry, true), nil
+}
+
+// Merge applies a remote entry using LWW conflict resolution.
+// Witnesses the entry's Lamport timestamp to advance the local clock.
+// Returns true if the incoming entry won and was applied.
+// Rejects entries that exceed size limits or have unsafe timestamps.
+func (m *Map) Merge(entry Entry) bool {
+	if len(entry.Key) > MaxKeyLen || len(entry.Value) > MaxValueLen {
+		logger.Warn("rejecting oversized entry", "key_len", len(entry.Key), "value_len", len(entry.Value))
+		return false
+	}
+	if entry.LamportTs > MaxSafeLamportTs {
+		logger.Warn("rejecting entry with unsafe timestamp", "ts", entry.LamportTs, "key", entry.Key)
+		return false
+	}
+	m.clock.Witness(entry.LamportTs)
+	return m.merge(entry, false)
+}
+
+func (m *Map) merge(entry Entry, notify bool) bool {
+	m.mu.Lock()
+	existing, exists := m.entries[entry.Key]
+	if exists && !entry.Wins(existing) {
+		m.mu.Unlock()
+		return false
+	}
+	// Reject new keys when at capacity (updates to existing keys are always allowed).
+	if !exists && len(m.entries) >= MaxStateEntries {
+		m.mu.Unlock()
+		logger.Warn("state map at capacity, rejecting new key", "key", entry.Key)
+		return false
+	}
+	m.entries[entry.Key] = entry
+	m.mu.Unlock()
+
+	if notify && m.onChange != nil {
+		m.onChange(entry)
+	}
+	return true
+}
+
+// Get returns the entry for a key, or false if not found.
+func (m *Map) Get(key string) (Entry, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	e, ok := m.entries[key]
+	return e, ok
+}
+
+// Snapshot returns a copy of all entries.
+func (m *Map) Snapshot() []Entry {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	entries := make([]Entry, 0, len(m.entries))
+	for _, e := range m.entries {
+		entries = append(entries, e)
+	}
+	return entries
+}
+
+// Len returns the number of entries in the map.
+func (m *Map) Len() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return len(m.entries)
+}

--- a/internal/state/map_test.go
+++ b/internal/state/map_test.go
@@ -1,13 +1,51 @@
 package state
 
 import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 )
 
+// testID generates an ED25519 key pair and derives the nodeID (sha256 hex of pubkey).
+func testID(t *testing.T) (string, ed25519.PrivateKey) {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pub := priv.Public().(ed25519.PublicKey)
+	hash := sha256.Sum256(pub)
+	nodeID := hex.EncodeToString(hash[:])
+	return nodeID, priv
+}
+
+// testMap creates a Map with a freshly generated identity.
+func testMap(t *testing.T) (*Map, string) {
+	t.Helper()
+	nodeID, priv := testID(t)
+	return NewMap(nodeID, priv), nodeID
+}
+
+// testSignedEntry creates a properly signed entry from the given identity.
+func testSignedEntry(nodeID string, privKey ed25519.PrivateKey, subkey string, value []byte, ts uint64, deleted bool) Entry {
+	e := Entry{
+		Key:       nodeID + "/" + subkey,
+		Value:     value,
+		LamportTs: ts,
+		NodeID:    nodeID,
+		Deleted:   deleted,
+	}
+	SignEntry(&e, privKey)
+	return e
+}
+
 func TestMapSetAndGet(t *testing.T) {
-	m := NewMap("node-a")
+	m, nodeID := testMap(t)
 	entry, ok, err := m.Set("color", []byte("blue"))
 	if err != nil {
 		t.Fatal(err)
@@ -19,83 +57,91 @@ func TestMapSetAndGet(t *testing.T) {
 		t.Fatalf("LamportTs = %d, want 1", entry.LamportTs)
 	}
 
-	got, found := m.Get("color")
+	fullKey := nodeID + "/color"
+	got, found := m.Get(fullKey)
 	if !found {
 		t.Fatal("Get returned not found")
 	}
 	if string(got.Value) != "blue" {
 		t.Fatalf("Value = %q, want %q", got.Value, "blue")
 	}
-	if got.NodeID != "node-a" {
-		t.Fatalf("NodeID = %q, want %q", got.NodeID, "node-a")
+	if got.NodeID != nodeID {
+		t.Fatalf("NodeID = %q, want %q", got.NodeID, nodeID)
 	}
 }
 
 func TestMapGetNotFound(t *testing.T) {
-	m := NewMap("node-a")
-	_, found := m.Get("missing")
+	m, nodeID := testMap(t)
+	_, found := m.Get(nodeID + "/missing")
 	if found {
 		t.Fatal("expected not found")
 	}
 }
 
 func TestMapLWWHigherTsWins(t *testing.T) {
-	m := NewMap("node-a")
+	m, _ := testMap(t)
 	m.Set("key", []byte("old"))
 
-	won := m.Merge(Entry{Key: "key", Value: []byte("new"), LamportTs: 100, NodeID: "node-b"})
+	remoteID, remotePriv := testID(t)
+	remote := testSignedEntry(remoteID, remotePriv, "key", []byte("new"), 100, false)
+	won := m.Merge(remote)
 	if !won {
 		t.Fatal("higher ts should win")
 	}
-	got, _ := m.Get("key")
+	got, _ := m.Get(remote.Key)
 	if string(got.Value) != "new" {
 		t.Fatalf("Value = %q, want %q", got.Value, "new")
 	}
 }
 
 func TestMapLWWLowerTsLoses(t *testing.T) {
-	m := NewMap("node-a")
+	m, _ := testMap(t)
+	remoteID, remotePriv := testID(t)
 
-	// Set a value with high ts via merge
-	m.Merge(Entry{Key: "key", Value: []byte("winner"), LamportTs: 100, NodeID: "node-b"})
+	// Set a value with high ts
+	high := testSignedEntry(remoteID, remotePriv, "key", []byte("winner"), 100, false)
+	m.Merge(high)
 
-	// Try to merge a lower ts — should be rejected
-	won := m.Merge(Entry{Key: "key", Value: []byte("loser"), LamportTs: 50, NodeID: "node-c"})
+	// Try to merge a lower ts from the SAME node — should be rejected
+	low := testSignedEntry(remoteID, remotePriv, "key", []byte("loser"), 50, false)
+	won := m.Merge(low)
 	if won {
 		t.Fatal("lower ts should lose")
 	}
-	got, _ := m.Get("key")
+	got, _ := m.Get(high.Key)
 	if string(got.Value) != "winner" {
 		t.Fatalf("Value = %q, want %q", got.Value, "winner")
 	}
 }
 
 func TestMapLWWTieBreakerNodeID(t *testing.T) {
-	m := NewMap("node-a")
+	m, _ := testMap(t)
+	id1, priv1 := testID(t)
+	id2, priv2 := testID(t)
 
-	m.Merge(Entry{Key: "key", Value: []byte("from-b"), LamportTs: 5, NodeID: "node-b"})
-	won := m.Merge(Entry{Key: "key", Value: []byte("from-c"), LamportTs: 5, NodeID: "node-c"})
-	if !won {
-		t.Fatal("higher node_id should win tie")
-	}
-	got, _ := m.Get("key")
-	if string(got.Value) != "from-c" {
-		t.Fatalf("Value = %q, want %q", got.Value, "from-c")
-	}
+	e1 := testSignedEntry(id1, priv1, "key", []byte("from-1"), 5, false)
+	e2 := testSignedEntry(id2, priv2, "key", []byte("from-2"), 5, false)
+	m.Merge(e1)
+	m.Merge(e2)
 
-	// node-a has lower node_id, should lose tie
-	won = m.Merge(Entry{Key: "key", Value: []byte("from-a"), LamportTs: 5, NodeID: "node-a"})
-	if won {
-		t.Fatal("lower node_id should lose tie")
+	// Both have same ts=5 — higher nodeID wins
+	winner := id1
+	wantVal := "from-1"
+	if id2 > id1 {
+		winner = id2
+		wantVal = "from-2"
 	}
-	got, _ = m.Get("key")
-	if string(got.Value) != "from-c" {
-		t.Fatalf("Value = %q, want %q", got.Value, "from-c")
+	got, found := m.Get(winner + "/key")
+	if !found {
+		t.Fatal("winner key not found")
+	}
+	if string(got.Value) != wantVal {
+		t.Fatalf("Value = %q, want %q", got.Value, wantVal)
 	}
 }
 
 func TestMapSnapshot(t *testing.T) {
-	m := NewMap("node-a")
+	m, nodeID := testMap(t)
 	m.Set("a", []byte("1"))
 	m.Set("b", []byte("2"))
 	m.Set("c", []byte("3"))
@@ -110,14 +156,15 @@ func TestMapSnapshot(t *testing.T) {
 		keys[e.Key] = true
 	}
 	for _, k := range []string{"a", "b", "c"} {
-		if !keys[k] {
-			t.Fatalf("missing key %q in snapshot", k)
+		fullKey := nodeID + "/" + k
+		if !keys[fullKey] {
+			t.Fatalf("missing key %q in snapshot", fullKey)
 		}
 	}
 }
 
 func TestMapLen(t *testing.T) {
-	m := NewMap("node-a")
+	m, _ := testMap(t)
 	if m.Len() != 0 {
 		t.Fatalf("Len() = %d, want 0", m.Len())
 	}
@@ -128,33 +175,37 @@ func TestMapLen(t *testing.T) {
 }
 
 func TestMapChangeHandlerCalledOnSet(t *testing.T) {
-	m := NewMap("node-a")
+	m, nodeID := testMap(t)
 	var called Entry
 	m.SetChangeHandler(func(entry Entry) {
 		called = entry
 	})
 
 	m.Set("color", []byte("red"))
-	if called.Key != "color" || string(called.Value) != "red" {
+	wantKey := nodeID + "/color"
+	if called.Key != wantKey || string(called.Value) != "red" {
 		t.Fatalf("ChangeHandler not called correctly: got %+v", called)
 	}
 }
 
 func TestMapChangeHandlerNotCalledOnMerge(t *testing.T) {
-	m := NewMap("node-a")
+	m, _ := testMap(t)
 	callCount := 0
 	m.SetChangeHandler(func(entry Entry) {
 		callCount++
 	})
 
-	m.Merge(Entry{Key: "key", Value: []byte("val"), LamportTs: 10, NodeID: "node-b"})
+	remoteID, remotePriv := testID(t)
+	e := testSignedEntry(remoteID, remotePriv, "key", []byte("val"), 10, false)
+	m.Merge(e)
 	if callCount != 0 {
 		t.Fatalf("ChangeHandler called %d times on Merge, want 0", callCount)
 	}
 }
 
 func TestMapConcurrentAccess(t *testing.T) {
-	m := NewMap("node-a")
+	m, nodeID := testMap(t)
+	remoteID, remotePriv := testID(t)
 	var wg sync.WaitGroup
 	n := 100
 
@@ -166,18 +217,19 @@ func TestMapConcurrentAccess(t *testing.T) {
 		}()
 		go func(ts uint64) {
 			defer wg.Done()
-			m.Merge(Entry{Key: "key", Value: []byte("remote"), LamportTs: ts, NodeID: "node-b"})
+			e := testSignedEntry(remoteID, remotePriv, "key", []byte("remote"), ts, false)
+			m.Merge(e)
 		}(uint64(i))
 		go func() {
 			defer wg.Done()
-			m.Get("key")
+			m.Get(nodeID + "/key")
 		}()
 	}
 	wg.Wait()
 
-	// Should have exactly one key
-	if m.Len() != 1 {
-		t.Fatalf("Len() = %d, want 1", m.Len())
+	// Should have at most 2 keys (one per namespace)
+	if m.Len() > 2 {
+		t.Fatalf("Len() = %d, want <= 2", m.Len())
 	}
 }
 
@@ -205,16 +257,17 @@ func TestEntryWins(t *testing.T) {
 // --- Security validation tests ---
 
 func TestMapRejectsOversizedKey(t *testing.T) {
-	m := NewMap("node-a")
-	longKey := strings.Repeat("x", MaxKeyLen+1)
-	_, _, err := m.Set(longKey, []byte("val"))
+	m, _ := testMap(t)
+	// nodeID is 64 hex chars + "/" = 65 chars prefix. MaxKeyLen=256, so subkey > 191 overflows.
+	longSubkey := strings.Repeat("x", MaxKeyLen)
+	_, _, err := m.Set(longSubkey, []byte("val"))
 	if err != ErrKeyTooLong {
 		t.Fatalf("expected ErrKeyTooLong, got %v", err)
 	}
 }
 
 func TestMapRejectsOversizedValue(t *testing.T) {
-	m := NewMap("node-a")
+	m, _ := testMap(t)
 	longVal := make([]byte, MaxValueLen+1)
 	_, _, err := m.Set("key", longVal)
 	if err != ErrValueTooLong {
@@ -222,24 +275,23 @@ func TestMapRejectsOversizedValue(t *testing.T) {
 	}
 }
 
-func TestMapMergeRejectsOversized(t *testing.T) {
-	m := NewMap("node-a")
+func TestMapMergeRejectsOversizedValue(t *testing.T) {
+	m, _ := testMap(t)
+	remoteID, remotePriv := testID(t)
 
-	won := m.Merge(Entry{Key: strings.Repeat("x", MaxKeyLen+1), Value: []byte("v"), LamportTs: 1, NodeID: "b"})
-	if won {
-		t.Fatal("oversized key should be rejected")
-	}
-
-	won = m.Merge(Entry{Key: "k", Value: make([]byte, MaxValueLen+1), LamportTs: 1, NodeID: "b"})
+	e := testSignedEntry(remoteID, remotePriv, "k", make([]byte, MaxValueLen+1), 1, false)
+	won := m.Merge(e)
 	if won {
 		t.Fatal("oversized value should be rejected")
 	}
 }
 
 func TestMapMergeRejectsUnsafeTimestamp(t *testing.T) {
-	m := NewMap("node-a")
+	m, _ := testMap(t)
+	remoteID, remotePriv := testID(t)
 
-	won := m.Merge(Entry{Key: "key", Value: []byte("val"), LamportTs: MaxSafeLamportTs + 1, NodeID: "b"})
+	e := testSignedEntry(remoteID, remotePriv, "key", []byte("val"), MaxSafeLamportTs+1, false)
+	won := m.Merge(e)
 	if won {
 		t.Fatal("unsafe timestamp should be rejected")
 	}
@@ -251,25 +303,529 @@ func TestMapMergeRejectsUnsafeTimestamp(t *testing.T) {
 }
 
 func TestMapRejectsNewKeysAtCapacity(t *testing.T) {
-	m := NewMap("node-a")
+	m, _ := testMap(t)
+	remoteID, remotePriv := testID(t)
 
 	// Fill to capacity
 	for i := 0; i < MaxStateEntries; i++ {
-		m.Merge(Entry{Key: string(rune(i)), Value: []byte("v"), LamportTs: uint64(i + 1), NodeID: "b"})
+		e := testSignedEntry(remoteID, remotePriv, fmt.Sprintf("k%d", i), []byte("v"), uint64(i+1), false)
+		m.Merge(e)
 	}
 	if m.Len() != MaxStateEntries {
 		t.Fatalf("Len() = %d, want %d", m.Len(), MaxStateEntries)
 	}
 
-	// New key should be rejected
-	won := m.Merge(Entry{Key: "new-key", Value: []byte("v"), LamportTs: 999999, NodeID: "b"})
+	// New key from a different node should be rejected
+	remote2ID, remote2Priv := testID(t)
+	e := testSignedEntry(remote2ID, remote2Priv, "new", []byte("v"), 999999, false)
+	won := m.Merge(e)
 	if won {
 		t.Fatal("new key at capacity should be rejected")
 	}
 
 	// Update to existing key should still work
-	won = m.Merge(Entry{Key: string(rune(0)), Value: []byte("updated"), LamportTs: 999999, NodeID: "b"})
+	update := testSignedEntry(remoteID, remotePriv, "k0", []byte("updated"), 999999, false)
+	won = m.Merge(update)
 	if !won {
 		t.Fatal("update to existing key should still work at capacity")
+	}
+}
+
+// --- Signature verification tests ---
+
+func TestMapMergeRejectsUnsignedEntry(t *testing.T) {
+	m, _ := testMap(t)
+	remoteID, _ := testID(t)
+
+	e := Entry{
+		Key:       remoteID + "/key",
+		Value:     []byte("val"),
+		LamportTs: 1,
+		NodeID:    remoteID,
+	}
+	won := m.Merge(e)
+	if won {
+		t.Fatal("unsigned entry should be rejected")
+	}
+}
+
+func TestMapMergeRejectsWrongNamespace(t *testing.T) {
+	m, _ := testMap(t)
+	remoteID, remotePriv := testID(t)
+	otherID, _ := testID(t)
+
+	// Sign entry but put it under another node's namespace
+	e := Entry{
+		Key:       otherID + "/key",
+		Value:     []byte("val"),
+		LamportTs: 1,
+		NodeID:    remoteID,
+	}
+	SignEntry(&e, remotePriv)
+	won := m.Merge(e)
+	if won {
+		t.Fatal("entry in wrong namespace should be rejected")
+	}
+}
+
+func TestMapMergeRejectsTamperedValue(t *testing.T) {
+	m, _ := testMap(t)
+	remoteID, remotePriv := testID(t)
+
+	e := testSignedEntry(remoteID, remotePriv, "key", []byte("original"), 1, false)
+	e.Value = []byte("tampered")
+	won := m.Merge(e)
+	if won {
+		t.Fatal("tampered entry should be rejected")
+	}
+}
+
+// --- Tombstone tests ---
+
+func TestMapDeleteAndGet(t *testing.T) {
+	m, nodeID := testMap(t)
+	m.Set("color", []byte("blue"))
+
+	entry, ok, err := m.Delete("color")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("Delete rejected")
+	}
+	if !entry.Deleted {
+		t.Fatal("entry should be marked deleted")
+	}
+	if entry.LamportTs < 2 {
+		t.Fatalf("Delete ts should be > Set ts, got %d", entry.LamportTs)
+	}
+
+	_, found := m.Get(nodeID + "/color")
+	if found {
+		t.Fatal("Get should return false for deleted key")
+	}
+}
+
+func TestMapDeleteNonExistentKey(t *testing.T) {
+	m, _ := testMap(t)
+	entry, ok, err := m.Delete("missing")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("Delete of non-existent key should succeed (creates tombstone)")
+	}
+	if !entry.Deleted {
+		t.Fatal("entry should be marked deleted")
+	}
+	if m.Len() != 1 {
+		t.Fatalf("Len() = %d, want 1", m.Len())
+	}
+}
+
+func TestMapDeleteWinsOverOlderSet(t *testing.T) {
+	m, _ := testMap(t)
+	remoteID, remotePriv := testID(t)
+
+	e := testSignedEntry(remoteID, remotePriv, "key", []byte("val"), 1, false)
+	m.Merge(e)
+
+	tomb := testSignedEntry(remoteID, remotePriv, "key", nil, 100, true)
+	won := m.Merge(tomb)
+	if !won {
+		t.Fatal("tombstone with higher ts should win")
+	}
+	_, found := m.Get(remoteID + "/key")
+	if found {
+		t.Fatal("key should be hidden after tombstone")
+	}
+}
+
+func TestMapSetResurrectsDelete(t *testing.T) {
+	m, nodeID := testMap(t)
+	m.Set("key", []byte("first"))
+	m.Delete("key")
+
+	entry, ok, _ := m.Set("key", []byte("resurrected"))
+	if !ok {
+		t.Fatal("Set after Delete should win")
+	}
+	if entry.Deleted {
+		t.Fatal("new Set should not be deleted")
+	}
+
+	got, found := m.Get(nodeID + "/key")
+	if !found {
+		t.Fatal("key should be visible after resurrection")
+	}
+	if string(got.Value) != "resurrected" {
+		t.Fatalf("Value = %q, want %q", got.Value, "resurrected")
+	}
+}
+
+func TestMapDeleteValidation(t *testing.T) {
+	m, _ := testMap(t)
+	longSubkey := strings.Repeat("x", MaxKeyLen)
+	_, _, err := m.Delete(longSubkey)
+	if err != ErrKeyTooLong {
+		t.Fatalf("expected ErrKeyTooLong, got %v", err)
+	}
+}
+
+func TestMapDeleteNotifiesChangeHandler(t *testing.T) {
+	m, nodeID := testMap(t)
+	var called Entry
+	m.SetChangeHandler(func(entry Entry) {
+		called = entry
+	})
+
+	m.Delete("key")
+	wantKey := nodeID + "/key"
+	if called.Key != wantKey || !called.Deleted {
+		t.Fatalf("ChangeHandler not called on Delete: got %+v", called)
+	}
+}
+
+func TestMapSnapshotIncludesTombstones(t *testing.T) {
+	m, nodeID := testMap(t)
+	m.Set("live", []byte("val"))
+	m.Set("doomed", []byte("val"))
+	m.Delete("doomed")
+
+	snap := m.Snapshot()
+	if len(snap) != 2 {
+		t.Fatalf("Snapshot len = %d, want 2 (including tombstone)", len(snap))
+	}
+
+	doomedKey := nodeID + "/doomed"
+	var foundTombstone bool
+	for _, e := range snap {
+		if e.Key == doomedKey && e.Deleted {
+			foundTombstone = true
+		}
+	}
+	if !foundTombstone {
+		t.Fatal("Snapshot should include tombstone for 'doomed'")
+	}
+}
+
+func TestMapGC(t *testing.T) {
+	m, nodeID := testMap(t)
+	m.Set("live", []byte("val"))
+	m.Delete("dead")
+
+	deadKey := nodeID + "/dead"
+	removed := m.GC(0)
+	if len(removed) != 1 || removed[0] != deadKey {
+		t.Fatalf("GC removed = %v, want [%s]", removed, deadKey)
+	}
+	if m.Len() != 1 {
+		t.Fatalf("Len() = %d, want 1 after GC", m.Len())
+	}
+	_, found := m.Get(nodeID + "/live")
+	if !found {
+		t.Fatal("live entry should survive GC")
+	}
+}
+
+func TestMapGCPreservesRecentTombstones(t *testing.T) {
+	m, _ := testMap(t)
+	m.Delete("recent")
+
+	removed := m.GC(24 * time.Hour)
+	if len(removed) != 0 {
+		t.Fatalf("GC removed %d entries, want 0", len(removed))
+	}
+	if m.Len() != 1 {
+		t.Fatalf("Len() = %d, want 1", m.Len())
+	}
+}
+
+func TestMapGCResurrectedKeyNotCollected(t *testing.T) {
+	m, nodeID := testMap(t)
+	m.Delete("key")
+	m.Set("key", []byte("alive"))
+
+	removed := m.GC(0)
+	if len(removed) != 0 {
+		t.Fatalf("GC removed %d entries, want 0 (key was resurrected)", len(removed))
+	}
+
+	got, found := m.Get(nodeID + "/key")
+	if !found || string(got.Value) != "alive" {
+		t.Fatal("resurrected key should survive GC")
+	}
+}
+
+// --- Digest / SnapshotDelta tests ---
+
+func TestDigest(t *testing.T) {
+	m, nodeID := testMap(t)
+	m.Set("a", []byte("1")) // ts=1
+	m.Set("b", []byte("2")) // ts=2
+
+	remoteID, remotePriv := testID(t)
+	e := testSignedEntry(remoteID, remotePriv, "x", []byte("v"), 50, false)
+	m.Merge(e)
+
+	d := m.Digest()
+	if len(d) != 2 {
+		t.Fatalf("Digest len = %d, want 2", len(d))
+	}
+	if d[nodeID] != 2 {
+		t.Fatalf("Digest[local] = %d, want 2", d[nodeID])
+	}
+	if d[remoteID] != 50 {
+		t.Fatalf("Digest[remote] = %d, want 50", d[remoteID])
+	}
+}
+
+func TestDigestEmpty(t *testing.T) {
+	m, _ := testMap(t)
+	d := m.Digest()
+	if len(d) != 0 {
+		t.Fatalf("Digest len = %d, want 0", len(d))
+	}
+}
+
+func TestSnapshotDelta(t *testing.T) {
+	m, nodeID := testMap(t)
+	m.Set("a", []byte("1")) // ts=1
+	m.Set("b", []byte("2")) // ts=2
+
+	remoteID, remotePriv := testID(t)
+	e1 := testSignedEntry(remoteID, remotePriv, "x", []byte("old"), 10, false)
+	e2 := testSignedEntry(remoteID, remotePriv, "y", []byte("new"), 50, false)
+	m.Merge(e1)
+	m.Merge(e2)
+
+	// Peer already knows: local up to ts=1, remote up to ts=10
+	known := map[string]uint64{
+		nodeID:   1,
+		remoteID: 10,
+	}
+	delta := m.SnapshotDelta(known)
+
+	// Should get: local "b" (ts=2 > 1) and remote "y" (ts=50 > 10)
+	if len(delta) != 2 {
+		t.Fatalf("SnapshotDelta len = %d, want 2", len(delta))
+	}
+	keys := make(map[string]bool)
+	for _, e := range delta {
+		keys[e.Key] = true
+	}
+	if !keys[nodeID+"/b"] {
+		t.Fatal("delta should include local 'b' (ts=2 > known=1)")
+	}
+	if !keys[remoteID+"/y"] {
+		t.Fatal("delta should include remote 'y' (ts=50 > known=10)")
+	}
+}
+
+func TestSnapshotDeltaEmptyKnown(t *testing.T) {
+	m, _ := testMap(t)
+	m.Set("a", []byte("1"))
+	m.Set("b", []byte("2"))
+
+	remoteID, remotePriv := testID(t)
+	e := testSignedEntry(remoteID, remotePriv, "x", []byte("v"), 10, false)
+	m.Merge(e)
+
+	// Empty known = send everything (fresh node)
+	delta := m.SnapshotDelta(nil)
+	if len(delta) != 3 {
+		t.Fatalf("SnapshotDelta(nil) len = %d, want 3", len(delta))
+	}
+
+	delta = m.SnapshotDelta(map[string]uint64{})
+	if len(delta) != 3 {
+		t.Fatalf("SnapshotDelta({}) len = %d, want 3", len(delta))
+	}
+}
+
+func TestSnapshotDeltaUnknownNode(t *testing.T) {
+	m, nodeID := testMap(t)
+	m.Set("a", []byte("1"))
+
+	remoteID, remotePriv := testID(t)
+	e := testSignedEntry(remoteID, remotePriv, "x", []byte("v"), 10, false)
+	m.Merge(e)
+
+	// Peer knows local node but not remote — should get all remote entries
+	known := map[string]uint64{
+		nodeID: 999, // knows all local entries
+	}
+	delta := m.SnapshotDelta(known)
+	if len(delta) != 1 {
+		t.Fatalf("SnapshotDelta len = %d, want 1 (only unknown remote)", len(delta))
+	}
+	if delta[0].NodeID != remoteID {
+		t.Fatalf("delta entry NodeID = %q, want %q", delta[0].NodeID, remoteID)
+	}
+}
+
+// --- Benchmarks: 1000 nodes, 100 updates each ---
+
+// benchNode holds a pre-generated identity for benchmarks.
+type benchNode struct {
+	id   string
+	priv ed25519.PrivateKey
+}
+
+func benchGenID() (string, ed25519.PrivateKey) {
+	_, priv, _ := ed25519.GenerateKey(nil)
+	pub := priv.Public().(ed25519.PublicKey)
+	hash := sha256.Sum256(pub)
+	return hex.EncodeToString(hash[:]), priv
+}
+
+// populateBenchMap creates a map with numNodes nodes. Each node writes
+// updatesPerNode times to its "status" key (LWW keeps only the latest).
+// Node i's final timestamp is (i % updatesPerNode) + 1, giving a realistic
+// spread of update times across the network.
+func populateBenchMap(numNodes, updatesPerNode int) (*Map, []benchNode) {
+	localID, localPriv := benchGenID()
+	m := NewMap(localID, localPriv)
+
+	nodes := make([]benchNode, numNodes)
+	for i := range nodes {
+		nodes[i].id, nodes[i].priv = benchGenID()
+	}
+
+	// Simulate each node updating at staggered times. Node i's latest
+	// update has ts = (i % updatesPerNode) + 1, so timestamps are
+	// uniformly distributed from 1 to updatesPerNode.
+	for i, n := range nodes {
+		finalTs := uint64(i%updatesPerNode) + 1
+		e := Entry{
+			Key:       n.id + "/status",
+			Value:     []byte(fmt.Sprintf("round-%d", finalTs)),
+			LamportTs: finalTs,
+			NodeID:    n.id,
+		}
+		SignEntry(&e, n.priv)
+		m.mu.Lock()
+		m.entries[e.Key] = e
+		m.mu.Unlock()
+	}
+
+	return m, nodes
+}
+
+// buildDigestAt builds a version vector where the peer last synced at ts=syncedAt.
+// Nodes with final ts <= syncedAt are already known.
+func buildDigestAt(nodes []benchNode, updatesPerNode, syncedAt int) map[string]uint64 {
+	d := make(map[string]uint64, len(nodes))
+	for i, n := range nodes {
+		finalTs := uint64(i%updatesPerNode) + 1
+		if finalTs <= uint64(syncedAt) {
+			d[n.id] = finalTs // peer knows this node's latest
+		}
+		// Nodes with ts > syncedAt are NOT in the digest (peer doesn't have them)
+	}
+	return d
+}
+
+func BenchmarkDigest1000Nodes(b *testing.B) {
+	m, _ := populateBenchMap(1000, 100)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m.Digest()
+	}
+}
+
+func BenchmarkSnapshot1000Nodes(b *testing.B) {
+	m, _ := populateBenchMap(1000, 100)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m.Snapshot()
+	}
+}
+
+func BenchmarkSnapshotDeltaFreshPeer(b *testing.B) {
+	m, _ := populateBenchMap(1000, 100)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m.SnapshotDelta(nil)
+	}
+}
+
+func BenchmarkSnapshotDelta1PercentStale(b *testing.B) {
+	// Peer synced at ts=99 — misses only the ~1% of nodes with ts=100.
+	m, nodes := populateBenchMap(1000, 100)
+	stale := buildDigestAt(nodes, 100, 99)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m.SnapshotDelta(stale)
+	}
+}
+
+func BenchmarkSnapshotDelta50PercentStale(b *testing.B) {
+	m, nodes := populateBenchMap(1000, 100)
+	stale := buildDigestAt(nodes, 100, 50)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m.SnapshotDelta(stale)
+	}
+}
+
+func BenchmarkSnapshotDeltaFullyCaughtUp(b *testing.B) {
+	m, nodes := populateBenchMap(1000, 100)
+	caughtUp := buildDigestAt(nodes, 100, 100)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m.SnapshotDelta(caughtUp)
+	}
+}
+
+// TestDeltaSyncSavings demonstrates delta sync savings with 1000 nodes.
+// Node i's latest ts = (i % 100) + 1, giving a uniform spread 1..100.
+func TestDeltaSyncSavings(t *testing.T) {
+	const numNodes = 1000
+	const updatesPerNode = 100
+
+	m, nodes := populateBenchMap(numNodes, updatesPerNode)
+	full := m.Snapshot()
+	digest := m.Digest()
+
+	scenarios := []struct {
+		name     string
+		syncedAt int
+	}{
+		{"fresh peer (knows nothing)", 0},
+		{"50% stale (synced at ts=50)", 50},
+		{"10% stale (synced at ts=90)", 90},
+		{"1% stale (synced at ts=99)", 99},
+		{"fully caught up (ts=100)", 100},
+	}
+
+	t.Logf("")
+	t.Logf("=== Delta Sync: %d nodes, ts spread 1..%d ===", numNodes, updatesPerNode)
+	t.Logf("  Total entries in map:  %d", len(full))
+	t.Logf("  Digest size:           %d nodeIDs (~%d bytes)", len(digest), len(digest)*72)
+	t.Logf("")
+
+	for _, sc := range scenarios {
+		var known map[string]uint64
+		if sc.syncedAt > 0 {
+			known = buildDigestAt(nodes, updatesPerNode, sc.syncedAt)
+		}
+		delta := m.SnapshotDelta(known)
+		saving := 100 * (1 - float64(len(delta))/float64(len(full)))
+		t.Logf("  %-35s → %4d entries (saving %5.1f%%)", sc.name, len(delta), saving)
+	}
+
+	// Correctness checks
+	if len(full) != numNodes {
+		t.Fatalf("expected %d entries, got %d", numNodes, len(full))
+	}
+	freshDelta := m.SnapshotDelta(nil)
+	if len(freshDelta) != numNodes {
+		t.Fatalf("fresh peer should get all %d entries, got %d", numNodes, len(freshDelta))
+	}
+	caughtUp := buildDigestAt(nodes, updatesPerNode, updatesPerNode)
+	upDelta := m.SnapshotDelta(caughtUp)
+	if len(upDelta) != 0 {
+		t.Fatalf("caught-up peer should get 0 entries, got %d", len(upDelta))
 	}
 }

--- a/internal/state/map_test.go
+++ b/internal/state/map_test.go
@@ -1,0 +1,275 @@
+package state
+
+import (
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestMapSetAndGet(t *testing.T) {
+	m := NewMap("node-a")
+	entry, ok, err := m.Set("color", []byte("blue"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("Set rejected")
+	}
+	if entry.LamportTs != 1 {
+		t.Fatalf("LamportTs = %d, want 1", entry.LamportTs)
+	}
+
+	got, found := m.Get("color")
+	if !found {
+		t.Fatal("Get returned not found")
+	}
+	if string(got.Value) != "blue" {
+		t.Fatalf("Value = %q, want %q", got.Value, "blue")
+	}
+	if got.NodeID != "node-a" {
+		t.Fatalf("NodeID = %q, want %q", got.NodeID, "node-a")
+	}
+}
+
+func TestMapGetNotFound(t *testing.T) {
+	m := NewMap("node-a")
+	_, found := m.Get("missing")
+	if found {
+		t.Fatal("expected not found")
+	}
+}
+
+func TestMapLWWHigherTsWins(t *testing.T) {
+	m := NewMap("node-a")
+	m.Set("key", []byte("old"))
+
+	won := m.Merge(Entry{Key: "key", Value: []byte("new"), LamportTs: 100, NodeID: "node-b"})
+	if !won {
+		t.Fatal("higher ts should win")
+	}
+	got, _ := m.Get("key")
+	if string(got.Value) != "new" {
+		t.Fatalf("Value = %q, want %q", got.Value, "new")
+	}
+}
+
+func TestMapLWWLowerTsLoses(t *testing.T) {
+	m := NewMap("node-a")
+
+	// Set a value with high ts via merge
+	m.Merge(Entry{Key: "key", Value: []byte("winner"), LamportTs: 100, NodeID: "node-b"})
+
+	// Try to merge a lower ts — should be rejected
+	won := m.Merge(Entry{Key: "key", Value: []byte("loser"), LamportTs: 50, NodeID: "node-c"})
+	if won {
+		t.Fatal("lower ts should lose")
+	}
+	got, _ := m.Get("key")
+	if string(got.Value) != "winner" {
+		t.Fatalf("Value = %q, want %q", got.Value, "winner")
+	}
+}
+
+func TestMapLWWTieBreakerNodeID(t *testing.T) {
+	m := NewMap("node-a")
+
+	m.Merge(Entry{Key: "key", Value: []byte("from-b"), LamportTs: 5, NodeID: "node-b"})
+	won := m.Merge(Entry{Key: "key", Value: []byte("from-c"), LamportTs: 5, NodeID: "node-c"})
+	if !won {
+		t.Fatal("higher node_id should win tie")
+	}
+	got, _ := m.Get("key")
+	if string(got.Value) != "from-c" {
+		t.Fatalf("Value = %q, want %q", got.Value, "from-c")
+	}
+
+	// node-a has lower node_id, should lose tie
+	won = m.Merge(Entry{Key: "key", Value: []byte("from-a"), LamportTs: 5, NodeID: "node-a"})
+	if won {
+		t.Fatal("lower node_id should lose tie")
+	}
+	got, _ = m.Get("key")
+	if string(got.Value) != "from-c" {
+		t.Fatalf("Value = %q, want %q", got.Value, "from-c")
+	}
+}
+
+func TestMapSnapshot(t *testing.T) {
+	m := NewMap("node-a")
+	m.Set("a", []byte("1"))
+	m.Set("b", []byte("2"))
+	m.Set("c", []byte("3"))
+
+	snap := m.Snapshot()
+	if len(snap) != 3 {
+		t.Fatalf("Snapshot len = %d, want 3", len(snap))
+	}
+
+	keys := make(map[string]bool)
+	for _, e := range snap {
+		keys[e.Key] = true
+	}
+	for _, k := range []string{"a", "b", "c"} {
+		if !keys[k] {
+			t.Fatalf("missing key %q in snapshot", k)
+		}
+	}
+}
+
+func TestMapLen(t *testing.T) {
+	m := NewMap("node-a")
+	if m.Len() != 0 {
+		t.Fatalf("Len() = %d, want 0", m.Len())
+	}
+	m.Set("x", []byte("1"))
+	if m.Len() != 1 {
+		t.Fatalf("Len() = %d, want 1", m.Len())
+	}
+}
+
+func TestMapChangeHandlerCalledOnSet(t *testing.T) {
+	m := NewMap("node-a")
+	var called Entry
+	m.SetChangeHandler(func(entry Entry) {
+		called = entry
+	})
+
+	m.Set("color", []byte("red"))
+	if called.Key != "color" || string(called.Value) != "red" {
+		t.Fatalf("ChangeHandler not called correctly: got %+v", called)
+	}
+}
+
+func TestMapChangeHandlerNotCalledOnMerge(t *testing.T) {
+	m := NewMap("node-a")
+	callCount := 0
+	m.SetChangeHandler(func(entry Entry) {
+		callCount++
+	})
+
+	m.Merge(Entry{Key: "key", Value: []byte("val"), LamportTs: 10, NodeID: "node-b"})
+	if callCount != 0 {
+		t.Fatalf("ChangeHandler called %d times on Merge, want 0", callCount)
+	}
+}
+
+func TestMapConcurrentAccess(t *testing.T) {
+	m := NewMap("node-a")
+	var wg sync.WaitGroup
+	n := 100
+
+	wg.Add(n * 3)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			m.Set("key", []byte("val"))
+		}()
+		go func(ts uint64) {
+			defer wg.Done()
+			m.Merge(Entry{Key: "key", Value: []byte("remote"), LamportTs: ts, NodeID: "node-b"})
+		}(uint64(i))
+		go func() {
+			defer wg.Done()
+			m.Get("key")
+		}()
+	}
+	wg.Wait()
+
+	// Should have exactly one key
+	if m.Len() != 1 {
+		t.Fatalf("Len() = %d, want 1", m.Len())
+	}
+}
+
+func TestEntryWins(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b Entry
+		want bool
+	}{
+		{"higher ts wins", Entry{LamportTs: 10, NodeID: "a"}, Entry{LamportTs: 5, NodeID: "z"}, true},
+		{"lower ts loses", Entry{LamportTs: 5, NodeID: "z"}, Entry{LamportTs: 10, NodeID: "a"}, false},
+		{"tie: higher node wins", Entry{LamportTs: 5, NodeID: "z"}, Entry{LamportTs: 5, NodeID: "a"}, true},
+		{"tie: lower node loses", Entry{LamportTs: 5, NodeID: "a"}, Entry{LamportTs: 5, NodeID: "z"}, false},
+		{"tie: same node", Entry{LamportTs: 5, NodeID: "a"}, Entry{LamportTs: 5, NodeID: "a"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.a.Wins(tt.b); got != tt.want {
+				t.Errorf("(%v).Wins(%v) = %v, want %v", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}
+
+// --- Security validation tests ---
+
+func TestMapRejectsOversizedKey(t *testing.T) {
+	m := NewMap("node-a")
+	longKey := strings.Repeat("x", MaxKeyLen+1)
+	_, _, err := m.Set(longKey, []byte("val"))
+	if err != ErrKeyTooLong {
+		t.Fatalf("expected ErrKeyTooLong, got %v", err)
+	}
+}
+
+func TestMapRejectsOversizedValue(t *testing.T) {
+	m := NewMap("node-a")
+	longVal := make([]byte, MaxValueLen+1)
+	_, _, err := m.Set("key", longVal)
+	if err != ErrValueTooLong {
+		t.Fatalf("expected ErrValueTooLong, got %v", err)
+	}
+}
+
+func TestMapMergeRejectsOversized(t *testing.T) {
+	m := NewMap("node-a")
+
+	won := m.Merge(Entry{Key: strings.Repeat("x", MaxKeyLen+1), Value: []byte("v"), LamportTs: 1, NodeID: "b"})
+	if won {
+		t.Fatal("oversized key should be rejected")
+	}
+
+	won = m.Merge(Entry{Key: "k", Value: make([]byte, MaxValueLen+1), LamportTs: 1, NodeID: "b"})
+	if won {
+		t.Fatal("oversized value should be rejected")
+	}
+}
+
+func TestMapMergeRejectsUnsafeTimestamp(t *testing.T) {
+	m := NewMap("node-a")
+
+	won := m.Merge(Entry{Key: "key", Value: []byte("val"), LamportTs: MaxSafeLamportTs + 1, NodeID: "b"})
+	if won {
+		t.Fatal("unsafe timestamp should be rejected")
+	}
+
+	// Clock should NOT have been advanced
+	if m.Clock().Current() != 0 {
+		t.Fatalf("clock should still be 0, got %d", m.Clock().Current())
+	}
+}
+
+func TestMapRejectsNewKeysAtCapacity(t *testing.T) {
+	m := NewMap("node-a")
+
+	// Fill to capacity
+	for i := 0; i < MaxStateEntries; i++ {
+		m.Merge(Entry{Key: string(rune(i)), Value: []byte("v"), LamportTs: uint64(i + 1), NodeID: "b"})
+	}
+	if m.Len() != MaxStateEntries {
+		t.Fatalf("Len() = %d, want %d", m.Len(), MaxStateEntries)
+	}
+
+	// New key should be rejected
+	won := m.Merge(Entry{Key: "new-key", Value: []byte("v"), LamportTs: 999999, NodeID: "b"})
+	if won {
+		t.Fatal("new key at capacity should be rejected")
+	}
+
+	// Update to existing key should still work
+	won = m.Merge(Entry{Key: string(rune(0)), Value: []byte("updated"), LamportTs: 999999, NodeID: "b"})
+	if !won {
+		t.Fatal("update to existing key should still work at capacity")
+	}
+}

--- a/internal/state/persistence.go
+++ b/internal/state/persistence.go
@@ -11,6 +11,7 @@ var stateBucket = []byte("state")
 
 // LoadFromStore loads persisted state entries into the map and
 // sets the Lamport clock floor to the highest persisted timestamp.
+// Tombstones are loaded and tracked for GC with a fresh first-seen time.
 // Called once at startup. If st is nil, this is a no-op.
 func (m *Map) LoadFromStore(st store.Store) error {
 	if st == nil {
@@ -25,14 +26,20 @@ func (m *Map) LoadFromStore(st store.Store) error {
 			return nil
 		}
 		entry := Entry{
-			Key:       pbEntry.Key,
-			Value:     pbEntry.Value,
-			LamportTs: pbEntry.LamportTs,
-			NodeID:    pbEntry.NodeId,
+			Key:          pbEntry.Key,
+			Value:        pbEntry.Value,
+			LamportTs:    pbEntry.LamportTs,
+			NodeID:       pbEntry.NodeId,
+			Deleted:      pbEntry.Deleted,
+			Signature:    pbEntry.Signature,
+			AuthorPubkey: pbEntry.AuthorPubkey,
 		}
 		m.mu.Lock()
 		m.entries[entry.Key] = entry
 		m.mu.Unlock()
+		if entry.Deleted {
+			m.RecordTombstone(entry.Key)
+		}
 		if entry.LamportTs > maxTs {
 			maxTs = entry.LamportTs
 		}
@@ -56,10 +63,13 @@ func PersistEntry(st store.Store, entry Entry) {
 		return
 	}
 	pbEntry := &pb.StateEntry{
-		Key:       entry.Key,
-		Value:     entry.Value,
-		LamportTs: entry.LamportTs,
-		NodeId:    entry.NodeID,
+		Key:          entry.Key,
+		Value:        entry.Value,
+		LamportTs:    entry.LamportTs,
+		NodeId:       entry.NodeID,
+		Deleted:      entry.Deleted,
+		Signature:    entry.Signature,
+		AuthorPubkey: entry.AuthorPubkey,
 	}
 	data, err := proto.Marshal(pbEntry)
 	if err != nil {
@@ -68,5 +78,17 @@ func PersistEntry(st store.Store, entry Entry) {
 	}
 	if err := st.Set(stateBucket, []byte(entry.Key), data); err != nil {
 		logger.Error("persist state entry", "key", entry.Key, "err", err)
+	}
+}
+
+// DeleteEntry removes an entry from the store by key.
+// Used by GC to clean up tombstones from disk.
+// If st is nil, this is a no-op.
+func DeleteEntry(st store.Store, key string) {
+	if st == nil {
+		return
+	}
+	if err := st.Delete(stateBucket, []byte(key)); err != nil {
+		logger.Error("delete state entry from store", "key", key, "err", err)
 	}
 }

--- a/internal/state/persistence.go
+++ b/internal/state/persistence.go
@@ -1,0 +1,72 @@
+package state
+
+import (
+	"micelio/internal/store"
+	pb "micelio/pkg/proto"
+
+	"google.golang.org/protobuf/proto"
+)
+
+var stateBucket = []byte("state")
+
+// LoadFromStore loads persisted state entries into the map and
+// sets the Lamport clock floor to the highest persisted timestamp.
+// Called once at startup. If st is nil, this is a no-op.
+func (m *Map) LoadFromStore(st store.Store) error {
+	if st == nil {
+		return nil
+	}
+
+	var maxTs uint64
+	err := st.ForEach(stateBucket, func(key, value []byte) error {
+		var pbEntry pb.StateEntry
+		if err := proto.Unmarshal(value, &pbEntry); err != nil {
+			logger.Warn("skipping corrupt state entry", "key", string(key), "err", err)
+			return nil
+		}
+		entry := Entry{
+			Key:       pbEntry.Key,
+			Value:     pbEntry.Value,
+			LamportTs: pbEntry.LamportTs,
+			NodeID:    pbEntry.NodeId,
+		}
+		m.mu.Lock()
+		m.entries[entry.Key] = entry
+		m.mu.Unlock()
+		if entry.LamportTs > maxTs {
+			maxTs = entry.LamportTs
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	if maxTs > 0 {
+		m.clock.SetFloor(maxTs)
+		logger.Info("loaded state from store", "entries", m.Len(), "max_ts", maxTs)
+	}
+	return nil
+}
+
+// PersistEntry writes a single entry to the store.
+// If st is nil, this is a no-op.
+func PersistEntry(st store.Store, entry Entry) {
+	if st == nil {
+		return
+	}
+	pbEntry := &pb.StateEntry{
+		Key:       entry.Key,
+		Value:     entry.Value,
+		LamportTs: entry.LamportTs,
+		NodeId:    entry.NodeID,
+	}
+	data, err := proto.Marshal(pbEntry)
+	if err != nil {
+		logger.Error("marshal state entry for persistence", "key", entry.Key, "err", err)
+		return
+	}
+	if err := st.Set(stateBucket, []byte(entry.Key), data); err != nil {
+		logger.Error("persist state entry", "key", entry.Key, "err", err)
+	}
+}

--- a/internal/state/persistence_test.go
+++ b/internal/state/persistence_test.go
@@ -1,0 +1,147 @@
+package state
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	boltstore "micelio/internal/store/bolt"
+)
+
+func tempStore(t *testing.T) *boltstore.Store {
+	t.Helper()
+	dir := t.TempDir()
+	st, err := boltstore.Open(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	return st
+}
+
+func TestPersistAndLoad(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+
+	// Create store, persist entries
+	st, err := boltstore.Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	entries := []Entry{
+		{Key: "color", Value: []byte("blue"), LamportTs: 5, NodeID: "node-a"},
+		{Key: "size", Value: []byte("large"), LamportTs: 10, NodeID: "node-b"},
+		{Key: "shape", Value: []byte("round"), LamportTs: 3, NodeID: "node-a"},
+	}
+	for _, e := range entries {
+		PersistEntry(st, e)
+	}
+	_ = st.Close()
+
+	// Reopen store, load into a new map
+	st2, err := boltstore.Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = st2.Close() }()
+
+	m := NewMap("node-c")
+	if err := m.LoadFromStore(st2); err != nil {
+		t.Fatal(err)
+	}
+
+	if m.Len() != 3 {
+		t.Fatalf("Len() = %d, want 3", m.Len())
+	}
+
+	for _, want := range entries {
+		got, ok := m.Get(want.Key)
+		if !ok {
+			t.Fatalf("key %q not found", want.Key)
+		}
+		if string(got.Value) != string(want.Value) {
+			t.Fatalf("key %q: Value = %q, want %q", want.Key, got.Value, want.Value)
+		}
+		if got.LamportTs != want.LamportTs {
+			t.Fatalf("key %q: LamportTs = %d, want %d", want.Key, got.LamportTs, want.LamportTs)
+		}
+		if got.NodeID != want.NodeID {
+			t.Fatalf("key %q: NodeID = %q, want %q", want.Key, got.NodeID, want.NodeID)
+		}
+	}
+}
+
+func TestLoadSetsClockFloor(t *testing.T) {
+	st := tempStore(t)
+
+	PersistEntry(st, Entry{Key: "a", Value: []byte("1"), LamportTs: 42, NodeID: "node-a"})
+	PersistEntry(st, Entry{Key: "b", Value: []byte("2"), LamportTs: 99, NodeID: "node-b"})
+
+	m := NewMap("node-c")
+	if err := m.LoadFromStore(st); err != nil {
+		t.Fatal(err)
+	}
+
+	if m.Clock().Current() != 99 {
+		t.Fatalf("Clock.Current() = %d, want 99", m.Clock().Current())
+	}
+
+	// Next Tick should be 100
+	if got := m.Clock().Tick(); got != 100 {
+		t.Fatalf("Clock.Tick() = %d, want 100", got)
+	}
+}
+
+func TestLoadFromStoreEmpty(t *testing.T) {
+	st := tempStore(t)
+	m := NewMap("node-a")
+	if err := m.LoadFromStore(st); err != nil {
+		t.Fatal(err)
+	}
+	if m.Len() != 0 {
+		t.Fatalf("Len() = %d, want 0", m.Len())
+	}
+}
+
+func TestPersistEntryNilStore(t *testing.T) {
+	// Should not panic
+	PersistEntry(nil, Entry{Key: "key", Value: []byte("val"), LamportTs: 1, NodeID: "node-a"})
+}
+
+func TestLoadFromStoreNilStore(t *testing.T) {
+	m := NewMap("node-a")
+	if err := m.LoadFromStore(nil); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPersistEntryCorruptSkipped(t *testing.T) {
+	st := tempStore(t)
+
+	// Write corrupt data directly to the bucket
+	if err := st.Set([]byte("state"), []byte("corrupt-key"), []byte("not-a-protobuf")); err != nil {
+		t.Fatal(err)
+	}
+	// Write a valid entry
+	PersistEntry(st, Entry{Key: "valid", Value: []byte("ok"), LamportTs: 1, NodeID: "node-a"})
+
+	m := NewMap("node-b")
+	if err := m.LoadFromStore(st); err != nil {
+		t.Fatal(err)
+	}
+
+	// Only the valid entry should be loaded
+	if m.Len() != 1 {
+		t.Fatalf("Len() = %d, want 1", m.Len())
+	}
+	_, ok := m.Get("valid")
+	if !ok {
+		t.Fatal("valid key not found")
+	}
+}
+
+func init() {
+	// Suppress "data directory does not exist" warnings in test output
+	_ = os.MkdirAll(os.TempDir(), 0700)
+}

--- a/internal/state/persistence_test.go
+++ b/internal/state/persistence_test.go
@@ -1,6 +1,9 @@
 package state
 
 import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/hex"
 	"os"
 	"path/filepath"
 	"testing"
@@ -19,20 +22,48 @@ func tempStore(t *testing.T) *boltstore.Store {
 	return st
 }
 
+// persistTestID generates an identity for persistence tests.
+func persistTestID(t *testing.T) (string, ed25519.PrivateKey) {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pub := priv.Public().(ed25519.PublicKey)
+	hash := sha256.Sum256(pub)
+	return hex.EncodeToString(hash[:]), priv
+}
+
+// persistTestEntry creates a signed entry for persistence tests.
+func persistTestEntry(nodeID string, privKey ed25519.PrivateKey, subkey string, value []byte, ts uint64, deleted bool) Entry {
+	e := Entry{
+		Key:       nodeID + "/" + subkey,
+		Value:     value,
+		LamportTs: ts,
+		NodeID:    nodeID,
+		Deleted:   deleted,
+	}
+	SignEntry(&e, privKey)
+	return e
+}
+
 func TestPersistAndLoad(t *testing.T) {
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "test.db")
 
-	// Create store, persist entries
+	idA, privA := persistTestID(t)
+	idB, privB := persistTestID(t)
+
+	// Create store, persist signed entries
 	st, err := boltstore.Open(dbPath)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	entries := []Entry{
-		{Key: "color", Value: []byte("blue"), LamportTs: 5, NodeID: "node-a"},
-		{Key: "size", Value: []byte("large"), LamportTs: 10, NodeID: "node-b"},
-		{Key: "shape", Value: []byte("round"), LamportTs: 3, NodeID: "node-a"},
+		persistTestEntry(idA, privA, "color", []byte("blue"), 5, false),
+		persistTestEntry(idB, privB, "size", []byte("large"), 10, false),
+		persistTestEntry(idA, privA, "shape", []byte("round"), 3, false),
 	}
 	for _, e := range entries {
 		PersistEntry(st, e)
@@ -46,7 +77,8 @@ func TestPersistAndLoad(t *testing.T) {
 	}
 	defer func() { _ = st2.Close() }()
 
-	m := NewMap("node-c")
+	idC, privC := persistTestID(t)
+	m := NewMap(idC, privC)
 	if err := m.LoadFromStore(st2); err != nil {
 		t.Fatal(err)
 	}
@@ -74,11 +106,14 @@ func TestPersistAndLoad(t *testing.T) {
 
 func TestLoadSetsClockFloor(t *testing.T) {
 	st := tempStore(t)
+	idA, privA := persistTestID(t)
+	idB, privB := persistTestID(t)
 
-	PersistEntry(st, Entry{Key: "a", Value: []byte("1"), LamportTs: 42, NodeID: "node-a"})
-	PersistEntry(st, Entry{Key: "b", Value: []byte("2"), LamportTs: 99, NodeID: "node-b"})
+	PersistEntry(st, persistTestEntry(idA, privA, "a", []byte("1"), 42, false))
+	PersistEntry(st, persistTestEntry(idB, privB, "b", []byte("2"), 99, false))
 
-	m := NewMap("node-c")
+	idC, privC := persistTestID(t)
+	m := NewMap(idC, privC)
 	if err := m.LoadFromStore(st); err != nil {
 		t.Fatal(err)
 	}
@@ -87,7 +122,6 @@ func TestLoadSetsClockFloor(t *testing.T) {
 		t.Fatalf("Clock.Current() = %d, want 99", m.Clock().Current())
 	}
 
-	// Next Tick should be 100
 	if got := m.Clock().Tick(); got != 100 {
 		t.Fatalf("Clock.Tick() = %d, want 100", got)
 	}
@@ -95,7 +129,8 @@ func TestLoadSetsClockFloor(t *testing.T) {
 
 func TestLoadFromStoreEmpty(t *testing.T) {
 	st := tempStore(t)
-	m := NewMap("node-a")
+	idA, privA := persistTestID(t)
+	m := NewMap(idA, privA)
 	if err := m.LoadFromStore(st); err != nil {
 		t.Fatal(err)
 	}
@@ -105,12 +140,14 @@ func TestLoadFromStoreEmpty(t *testing.T) {
 }
 
 func TestPersistEntryNilStore(t *testing.T) {
-	// Should not panic
-	PersistEntry(nil, Entry{Key: "key", Value: []byte("val"), LamportTs: 1, NodeID: "node-a"})
+	idA, privA := persistTestID(t)
+	e := persistTestEntry(idA, privA, "key", []byte("val"), 1, false)
+	PersistEntry(nil, e) // should not panic
 }
 
 func TestLoadFromStoreNilStore(t *testing.T) {
-	m := NewMap("node-a")
+	idA, privA := persistTestID(t)
+	m := NewMap(idA, privA)
 	if err := m.LoadFromStore(nil); err != nil {
 		t.Fatal(err)
 	}
@@ -118,30 +155,127 @@ func TestLoadFromStoreNilStore(t *testing.T) {
 
 func TestPersistEntryCorruptSkipped(t *testing.T) {
 	st := tempStore(t)
+	idA, privA := persistTestID(t)
 
 	// Write corrupt data directly to the bucket
 	if err := st.Set([]byte("state"), []byte("corrupt-key"), []byte("not-a-protobuf")); err != nil {
 		t.Fatal(err)
 	}
 	// Write a valid entry
-	PersistEntry(st, Entry{Key: "valid", Value: []byte("ok"), LamportTs: 1, NodeID: "node-a"})
+	e := persistTestEntry(idA, privA, "valid", []byte("ok"), 1, false)
+	PersistEntry(st, e)
 
-	m := NewMap("node-b")
+	idB, privB := persistTestID(t)
+	m := NewMap(idB, privB)
 	if err := m.LoadFromStore(st); err != nil {
 		t.Fatal(err)
 	}
 
-	// Only the valid entry should be loaded
+	// Only the valid entry should be loaded (corrupt skipped)
 	if m.Len() != 1 {
 		t.Fatalf("Len() = %d, want 1", m.Len())
 	}
-	_, ok := m.Get("valid")
+	_, ok := m.Get(e.Key)
 	if !ok {
 		t.Fatal("valid key not found")
 	}
 }
 
+func TestPersistAndLoadTombstone(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	idA, privA := persistTestID(t)
+
+	// Persist a tombstone and a live entry
+	st1, err := boltstore.Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	deadEntry := persistTestEntry(idA, privA, "dead", nil, 5, true)
+	liveEntry := persistTestEntry(idA, privA, "live", []byte("val"), 3, false)
+	PersistEntry(st1, deadEntry)
+	PersistEntry(st1, liveEntry)
+	_ = st1.Close()
+
+	// Reload
+	st2, err := boltstore.Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = st2.Close() }()
+
+	idB, privB := persistTestID(t)
+	m := NewMap(idB, privB)
+	if err := m.LoadFromStore(st2); err != nil {
+		t.Fatal(err)
+	}
+
+	if m.Len() != 2 {
+		t.Fatalf("Len() = %d, want 2", m.Len())
+	}
+
+	// Get hides tombstone
+	_, found := m.Get(deadEntry.Key)
+	if found {
+		t.Fatal("tombstone should be hidden by Get")
+	}
+
+	// Live entry is visible
+	got, found := m.Get(liveEntry.Key)
+	if !found || string(got.Value) != "val" {
+		t.Fatal("live entry should be visible")
+	}
+}
+
+func TestPersistAndLoadSignatureRoundTrip(t *testing.T) {
+	st := tempStore(t)
+	idA, privA := persistTestID(t)
+
+	original := persistTestEntry(idA, privA, "key", []byte("val"), 42, false)
+	PersistEntry(st, original)
+
+	idB, privB := persistTestID(t)
+	m := NewMap(idB, privB)
+	if err := m.LoadFromStore(st); err != nil {
+		t.Fatal(err)
+	}
+
+	got, ok := m.Get(original.Key)
+	if !ok {
+		t.Fatal("key not found after reload")
+	}
+
+	// Verify signature fields survived persistence round-trip
+	if !VerifyEntry(got) {
+		t.Fatal("entry signature should still verify after persistence round-trip")
+	}
+}
+
+func TestDeleteEntryFromStore(t *testing.T) {
+	st := tempStore(t)
+	idA, privA := persistTestID(t)
+
+	e := persistTestEntry(idA, privA, "color", []byte("blue"), 1, false)
+	PersistEntry(st, e)
+
+	// Delete from store
+	DeleteEntry(st, e.Key)
+
+	// Load into a new map — should be empty
+	idB, privB := persistTestID(t)
+	m := NewMap(idB, privB)
+	if err := m.LoadFromStore(st); err != nil {
+		t.Fatal(err)
+	}
+	if m.Len() != 0 {
+		t.Fatalf("Len() = %d, want 0 after DeleteEntry", m.Len())
+	}
+}
+
+func TestDeleteEntryNilStore(t *testing.T) {
+	DeleteEntry(nil, "key") // should not panic
+}
+
 func init() {
-	// Suppress "data directory does not exist" warnings in test output
 	_ = os.MkdirAll(os.TempDir(), 0700)
 }

--- a/internal/state/persistence_test.go
+++ b/internal/state/persistence_test.go
@@ -4,7 +4,6 @@ import (
 	"crypto/ed25519"
 	"crypto/sha256"
 	"encoding/hex"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -274,8 +273,4 @@ func TestDeleteEntryFromStore(t *testing.T) {
 
 func TestDeleteEntryNilStore(t *testing.T) {
 	DeleteEntry(nil, "key") // should not panic
-}
-
-func init() {
-	_ = os.MkdirAll(os.TempDir(), 0700)
 }

--- a/internal/transport/discovery.go
+++ b/internal/transport/discovery.go
@@ -144,6 +144,7 @@ func (m *Manager) onPeerConnected(p *Peer) {
 
 	go m.saveKnownPeer(&snapshot)
 	m.sendPeerExchangeTo(p)
+	m.sendStateSyncRequestTo(p)
 }
 
 // exchangeLoop periodically sends PeerExchange to all connected peers.

--- a/internal/transport/peer.go
+++ b/internal/transport/peer.go
@@ -23,11 +23,14 @@ import (
 
 // Message type constants.
 const (
-	MsgTypePeerHello    uint32 = 1
-	MsgTypePeerHelloAck uint32 = 2
-	MsgTypeChat         uint32 = 3
-	MsgTypePeerExchange uint32 = 4
-	MsgTypeKeepalive    uint32 = 5
+	MsgTypePeerHello         uint32 = 1
+	MsgTypePeerHelloAck      uint32 = 2
+	MsgTypeChat              uint32 = 3
+	MsgTypePeerExchange      uint32 = 4
+	MsgTypeKeepalive         uint32 = 5
+	MsgTypeStateUpdate       uint32 = 6 // gossip-relayed state change
+	MsgTypeStateSyncRequest  uint32 = 7 // direct peer-to-peer
+	MsgTypeStateSyncResponse uint32 = 8 // direct peer-to-peer
 
 	seenTTL     = 5 * time.Minute
 	seenCleanup = 1 * time.Minute
@@ -57,8 +60,12 @@ type Peer struct {
 	onPeerExchange func(nodeID string, infos []*pb.PeerInfo)
 
 	// Callback for gossip-eligible messages (set by Manager).
-	// All msg_types except PeerHello/HelloAck/PeerExchange are routed here.
+	// All msg_types except PeerHello/HelloAck/PeerExchange/StateSync are routed here.
 	onGossipMessage func(fromPeerID string, env *pb.Envelope)
+
+	// Callbacks for state sync messages (set by Manager).
+	onStateSyncRequest  func(fromPeerID string)
+	onStateSyncResponse func(fromPeerID string, entries []*pb.StateEntry)
 
 	sendCh chan []byte // framed envelope bytes ready to write
 	done   chan struct{}
@@ -277,6 +284,45 @@ func (p *Peer) recvLoop() error {
 				continue
 			}
 			p.handlePeerExchange(&env)
+
+		case MsgTypeStateSyncRequest:
+			// Direct peer-to-peer: per-peer dedup + signature check.
+			if p.isDuplicate(env.MessageId) {
+				continue
+			}
+			if !verifySignature(&env, p.edPubKey) {
+				tlog.Warn("invalid signature on state_sync_request", "peer", formatNodeIDShort(p.NodeID), "msg_id", env.MessageId)
+				continue
+			}
+			if env.SenderId != p.NodeID {
+				tlog.Warn("sender_id mismatch on state_sync_request", "peer", formatNodeIDShort(p.NodeID), "claimed", env.SenderId)
+				continue
+			}
+			if p.onStateSyncRequest != nil {
+				p.onStateSyncRequest(p.NodeID)
+			}
+
+		case MsgTypeStateSyncResponse:
+			// Direct peer-to-peer: per-peer dedup + signature check.
+			if p.isDuplicate(env.MessageId) {
+				continue
+			}
+			if !verifySignature(&env, p.edPubKey) {
+				tlog.Warn("invalid signature on state_sync_response", "peer", formatNodeIDShort(p.NodeID), "msg_id", env.MessageId)
+				continue
+			}
+			if env.SenderId != p.NodeID {
+				tlog.Warn("sender_id mismatch on state_sync_response", "peer", formatNodeIDShort(p.NodeID), "claimed", env.SenderId)
+				continue
+			}
+			var resp pb.StateSyncResponse
+			if err := proto.Unmarshal(env.Payload, &resp); err != nil {
+				tlog.Error("unmarshal state_sync_response", "peer", formatNodeIDShort(p.NodeID), "err", err)
+				continue
+			}
+			if p.onStateSyncResponse != nil {
+				p.onStateSyncResponse(p.NodeID, resp.Entries)
+			}
 
 		case MsgTypePeerHello, MsgTypePeerHelloAck:
 			// Handshake messages are point-to-point only; never gossip-relay them.

--- a/internal/transport/state_integration_test.go
+++ b/internal/transport/state_integration_test.go
@@ -1,0 +1,338 @@
+package transport_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"micelio/internal/config"
+	"micelio/internal/identity"
+	"micelio/internal/logging"
+	"micelio/internal/partyline"
+	"micelio/internal/state"
+	boltstore "micelio/internal/store/bolt"
+	"micelio/internal/transport"
+)
+
+// TestStateSyncTwoNodes verifies that a /set on node A is visible on node B
+// after gossip propagation.
+func TestStateSyncTwoNodes(t *testing.T) {
+	logging.CaptureForTest()
+
+	type testNode struct {
+		id     *identity.Identity
+		hub    *partyline.Hub
+		mgr    *transport.Manager
+		ctx    context.Context
+		cancel context.CancelFunc
+	}
+
+	makeNode := func(name string) testNode {
+		id, err := identity.Load(t.TempDir())
+		if err != nil {
+			t.Fatalf("identity %s: %v", name, err)
+		}
+		hub := partyline.NewHub(name)
+		ctx, cancel := context.WithCancel(context.Background())
+		return testNode{id: id, hub: hub, ctx: ctx, cancel: cancel}
+	}
+
+	cleanup := func(n *testNode) {
+		if n.mgr != nil {
+			n.mgr.Stop()
+		}
+		n.cancel()
+		n.hub.Stop()
+	}
+
+	nodeA := makeNode("node-a")
+	nodeB := makeNode("node-b")
+	defer func() {
+		cleanup(&nodeB)
+		cleanup(&nodeA)
+	}()
+
+	// Start B (listener)
+	cfgB := &config.Config{
+		Node: config.NodeConfig{Name: "node-b"},
+		Network: config.NetworkConfig{
+			Listen:            "127.0.0.1:0",
+			ExchangeInterval:  noDiscovery,
+			DiscoveryInterval: noDiscovery,
+		},
+	}
+	mgrB, err := transport.NewManager(cfgB, nodeB.id, nodeB.hub, nil)
+	if err != nil {
+		t.Fatalf("manager B: %v", err)
+	}
+	nodeB.mgr = mgrB
+	go nodeB.hub.Run()
+	go func() { _ = mgrB.Start(nodeB.ctx) }()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for mgrB.Addr() == "" && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// Start A (bootstraps to B)
+	cfgA := &config.Config{
+		Node: config.NodeConfig{Name: "node-a"},
+		Network: config.NetworkConfig{
+			Listen:            "127.0.0.1:0",
+			Bootstrap:         []string{mgrB.Addr()},
+			ExchangeInterval:  noDiscovery,
+			DiscoveryInterval: noDiscovery,
+		},
+	}
+	mgrA, err := transport.NewManager(cfgA, nodeA.id, nodeA.hub, nil)
+	if err != nil {
+		t.Fatalf("manager A: %v", err)
+	}
+	nodeA.mgr = mgrA
+	go nodeA.hub.Run()
+	go func() { _ = mgrA.Start(nodeA.ctx) }()
+
+	// Wait for connection
+	deadline = time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if mgrA.PeerCount() > 0 && mgrB.PeerCount() > 0 {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if mgrA.PeerCount() == 0 {
+		t.Fatal("nodes not connected")
+	}
+
+	// Set on A
+	stateA := mgrA.StateMap()
+	entry, ok, err := stateA.Set("color", []byte("blue"))
+	if err != nil {
+		t.Fatalf("Set error: %v", err)
+	}
+	if !ok {
+		t.Fatal("Set rejected on A")
+	}
+	if entry.LamportTs == 0 {
+		t.Fatal("LamportTs should be > 0")
+	}
+
+	// Poll B until it has the value
+	stateB := mgrB.StateMap()
+	deadline = time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if e, found := stateB.Get("color"); found && string(e.Value) == "blue" {
+			// Verify metadata
+			if e.LamportTs != entry.LamportTs {
+				t.Fatalf("B LamportTs = %d, want %d", e.LamportTs, entry.LamportTs)
+			}
+			if e.NodeID != nodeA.id.NodeID {
+				t.Fatalf("B NodeID = %q, want %q", e.NodeID, nodeA.id.NodeID)
+			}
+			return // success
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatal("B did not receive state update from A")
+}
+
+// TestStateConflictDeterministicWinner verifies that both nodes converge to
+// the same winner when they write to the same key with the same timestamp.
+func TestStateConflictDeterministicWinner(t *testing.T) {
+	// Use maps directly (no network) to test pure LWW resolution.
+	mapA := state.NewMap("node-aaaa")
+	mapB := state.NewMap("node-bbbb")
+
+	// Both write to the same key. mapA gets ts=1, mapB gets ts=1.
+	entryA, _, _ := mapA.Set("key", []byte("from-A"))
+	entryB, _, _ := mapB.Set("key", []byte("from-B"))
+
+	if entryA.LamportTs != 1 || entryB.LamportTs != 1 {
+		t.Fatalf("expected both ts=1, got A=%d B=%d", entryA.LamportTs, entryB.LamportTs)
+	}
+
+	// Cross-merge: A receives B's entry, B receives A's entry
+	mapA.Merge(entryB)
+	mapB.Merge(entryA)
+
+	// Both should converge to the same winner
+	gotA, _ := mapA.Get("key")
+	gotB, _ := mapB.Get("key")
+
+	if string(gotA.Value) != string(gotB.Value) {
+		t.Fatalf("maps diverged: A=%q B=%q", gotA.Value, gotB.Value)
+	}
+
+	// The winner should be the one with the higher node_id (node-bbbb > node-aaaa)
+	if string(gotA.Value) != "from-B" {
+		t.Fatalf("expected 'from-B' to win (higher node_id), got %q", gotA.Value)
+	}
+}
+
+// TestStateSyncOnConnect verifies that when node B connects to node A,
+// B receives A's pre-existing state via the state sync protocol.
+func TestStateSyncOnConnect(t *testing.T) {
+	logging.CaptureForTest()
+
+	type testNode struct {
+		id     *identity.Identity
+		hub    *partyline.Hub
+		mgr    *transport.Manager
+		ctx    context.Context
+		cancel context.CancelFunc
+	}
+
+	cleanup := func(n *testNode) {
+		if n.mgr != nil {
+			n.mgr.Stop()
+		}
+		n.cancel()
+		n.hub.Stop()
+	}
+
+	// Start A and set state BEFORE B connects
+	idA, err := identity.Load(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	hubA := partyline.NewHub("node-a")
+	ctxA, cancelA := context.WithCancel(context.Background())
+	nodeA := testNode{id: idA, hub: hubA, ctx: ctxA, cancel: cancelA}
+	defer cleanup(&nodeA)
+
+	cfgA := &config.Config{
+		Node: config.NodeConfig{Name: "node-a"},
+		Network: config.NetworkConfig{
+			Listen:            "127.0.0.1:0",
+			ExchangeInterval:  noDiscovery,
+			DiscoveryInterval: noDiscovery,
+		},
+	}
+	mgrA, err := transport.NewManager(cfgA, idA, hubA, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	nodeA.mgr = mgrA
+	go hubA.Run()
+	go func() { _ = mgrA.Start(ctxA) }()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for mgrA.Addr() == "" && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// Set state on A before B connects
+	mgrA.StateMap().Set("x", []byte("1"))   //nolint:errcheck
+	mgrA.StateMap().Set("y", []byte("2"))   //nolint:errcheck
+
+	// Now start B and connect to A
+	idB, err := identity.Load(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	hubB := partyline.NewHub("node-b")
+	ctxB, cancelB := context.WithCancel(context.Background())
+	nodeB := testNode{id: idB, hub: hubB, ctx: ctxB, cancel: cancelB}
+	defer cleanup(&nodeB)
+
+	cfgB := &config.Config{
+		Node: config.NodeConfig{Name: "node-b"},
+		Network: config.NetworkConfig{
+			Listen:            "127.0.0.1:0",
+			Bootstrap:         []string{mgrA.Addr()},
+			ExchangeInterval:  noDiscovery,
+			DiscoveryInterval: noDiscovery,
+		},
+	}
+	mgrB, err := transport.NewManager(cfgB, idB, hubB, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	nodeB.mgr = mgrB
+	go hubB.Run()
+	go func() { _ = mgrB.Start(ctxB) }()
+
+	// Wait for connection
+	deadline = time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if mgrB.PeerCount() > 0 {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if mgrB.PeerCount() == 0 {
+		t.Fatal("B not connected to A")
+	}
+
+	// Poll B for both keys (should arrive via state sync)
+	stateB := mgrB.StateMap()
+	deadline = time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		ex, okX := stateB.Get("x")
+		ey, okY := stateB.Get("y")
+		if okX && okY && string(ex.Value) == "1" && string(ey.Value) == "2" {
+			return // success
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatal("B did not receive A's pre-existing state via sync")
+}
+
+// TestStatePersistenceRestart verifies that state survives a node restart
+// by persisting to bbolt and loading on startup.
+func TestStatePersistenceRestart(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+
+	// First "run": create store, state map, set entries
+	st1, err := boltstore.Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m1 := state.NewMap("node-a")
+	if err := m1.LoadFromStore(st1); err != nil {
+		t.Fatal(err)
+	}
+
+	e1, _, _ := m1.Set("color", []byte("red"))
+	state.PersistEntry(st1, e1)
+	e2, _, _ := m1.Set("size", []byte("large"))
+	state.PersistEntry(st1, e2)
+
+	_ = st1.Close()
+
+	// Second "run": reopen store, create new map, load
+	st2, err := boltstore.Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = st2.Close() }()
+
+	m2 := state.NewMap("node-a")
+	if err := m2.LoadFromStore(st2); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify entries are restored
+	if m2.Len() != 2 {
+		t.Fatalf("Len() = %d, want 2", m2.Len())
+	}
+
+	got, ok := m2.Get("color")
+	if !ok || string(got.Value) != "red" {
+		t.Fatalf("color = %q, want %q", got.Value, "red")
+	}
+
+	got, ok = m2.Get("size")
+	if !ok || string(got.Value) != "large" {
+		t.Fatalf("size = %q, want %q", got.Value, "large")
+	}
+
+	// Verify clock floor: next tick should be > max persisted ts
+	nextTs := m2.Clock().Tick()
+	if nextTs <= e2.LamportTs {
+		t.Fatalf("clock tick %d should be > max persisted ts %d", nextTs, e2.LamportTs)
+	}
+}

--- a/internal/transport/state_integration_test.go
+++ b/internal/transport/state_integration_test.go
@@ -2,6 +2,9 @@ package transport_test
 
 import (
 	"context"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/hex"
 	"path/filepath"
 	"testing"
 	"time"
@@ -16,7 +19,7 @@ import (
 )
 
 // TestStateSyncTwoNodes verifies that a /set on node A is visible on node B
-// after gossip propagation.
+// after gossip propagation. Keys are namespaced by nodeID.
 func TestStateSyncTwoNodes(t *testing.T) {
 	logging.CaptureForTest()
 
@@ -105,7 +108,7 @@ func TestStateSyncTwoNodes(t *testing.T) {
 		t.Fatal("nodes not connected")
 	}
 
-	// Set on A
+	// Set on A (subkey "color" → full key "<nodeA_ID>/color")
 	stateA := mgrA.StateMap()
 	entry, ok, err := stateA.Set("color", []byte("blue"))
 	if err != nil {
@@ -118,17 +121,21 @@ func TestStateSyncTwoNodes(t *testing.T) {
 		t.Fatal("LamportTs should be > 0")
 	}
 
-	// Poll B until it has the value
+	// Poll B until it has the value (using full key from A's namespace)
+	fullKey := nodeA.id.NodeID + "/color"
 	stateB := mgrB.StateMap()
 	deadline = time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
-		if e, found := stateB.Get("color"); found && string(e.Value) == "blue" {
-			// Verify metadata
+		if e, found := stateB.Get(fullKey); found && string(e.Value) == "blue" {
 			if e.LamportTs != entry.LamportTs {
 				t.Fatalf("B LamportTs = %d, want %d", e.LamportTs, entry.LamportTs)
 			}
 			if e.NodeID != nodeA.id.NodeID {
 				t.Fatalf("B NodeID = %q, want %q", e.NodeID, nodeA.id.NodeID)
+			}
+			// Verify the entry signature is valid after gossip propagation
+			if !state.VerifyEntry(e) {
+				t.Fatal("entry signature invalid after gossip propagation")
 			}
 			return // success
 		}
@@ -137,14 +144,23 @@ func TestStateSyncTwoNodes(t *testing.T) {
 	t.Fatal("B did not receive state update from A")
 }
 
-// TestStateConflictDeterministicWinner verifies that both nodes converge to
-// the same winner when they write to the same key with the same timestamp.
+// TestStateConflictDeterministicWinner verifies that LWW convergence works
+// with namespaced, signed entries. Each node writes under its own namespace.
 func TestStateConflictDeterministicWinner(t *testing.T) {
-	// Use maps directly (no network) to test pure LWW resolution.
-	mapA := state.NewMap("node-aaaa")
-	mapB := state.NewMap("node-bbbb")
+	_, privA, _ := ed25519.GenerateKey(nil)
+	pubA := privA.Public().(ed25519.PublicKey)
+	hashA := sha256.Sum256(pubA)
+	nodeIDA := hex.EncodeToString(hashA[:])
 
-	// Both write to the same key. mapA gets ts=1, mapB gets ts=1.
+	_, privB, _ := ed25519.GenerateKey(nil)
+	pubB := privB.Public().(ed25519.PublicKey)
+	hashB := sha256.Sum256(pubB)
+	nodeIDB := hex.EncodeToString(hashB[:])
+
+	mapA := state.NewMap(nodeIDA, privA)
+	mapB := state.NewMap(nodeIDB, privB)
+
+	// Each node writes to its own namespace
 	entryA, _, _ := mapA.Set("key", []byte("from-A"))
 	entryB, _, _ := mapB.Set("key", []byte("from-B"))
 
@@ -152,21 +168,27 @@ func TestStateConflictDeterministicWinner(t *testing.T) {
 		t.Fatalf("expected both ts=1, got A=%d B=%d", entryA.LamportTs, entryB.LamportTs)
 	}
 
-	// Cross-merge: A receives B's entry, B receives A's entry
+	// Cross-merge: both nodes receive each other's entries
 	mapA.Merge(entryB)
 	mapB.Merge(entryA)
 
-	// Both should converge to the same winner
-	gotA, _ := mapA.Get("key")
-	gotB, _ := mapB.Get("key")
-
-	if string(gotA.Value) != string(gotB.Value) {
-		t.Fatalf("maps diverged: A=%q B=%q", gotA.Value, gotB.Value)
+	// Both should see both entries (different namespaces, no conflict)
+	gotA1, okA1 := mapA.Get(nodeIDA + "/key")
+	gotA2, okA2 := mapA.Get(nodeIDB + "/key")
+	if !okA1 || !okA2 {
+		t.Fatalf("mapA should have both entries: own=%v remote=%v", okA1, okA2)
+	}
+	if string(gotA1.Value) != "from-A" || string(gotA2.Value) != "from-B" {
+		t.Fatalf("mapA values: own=%q remote=%q", gotA1.Value, gotA2.Value)
 	}
 
-	// The winner should be the one with the higher node_id (node-bbbb > node-aaaa)
-	if string(gotA.Value) != "from-B" {
-		t.Fatalf("expected 'from-B' to win (higher node_id), got %q", gotA.Value)
+	gotB1, okB1 := mapB.Get(nodeIDA + "/key")
+	gotB2, okB2 := mapB.Get(nodeIDB + "/key")
+	if !okB1 || !okB2 {
+		t.Fatalf("mapB should have both entries: remote=%v own=%v", okB1, okB2)
+	}
+	if string(gotB1.Value) != "from-A" || string(gotB2.Value) != "from-B" {
+		t.Fatalf("mapB values: remote=%q own=%q", gotB1.Value, gotB2.Value)
 	}
 }
 
@@ -222,9 +244,9 @@ func TestStateSyncOnConnect(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 
-	// Set state on A before B connects
-	mgrA.StateMap().Set("x", []byte("1"))   //nolint:errcheck
-	mgrA.StateMap().Set("y", []byte("2"))   //nolint:errcheck
+	// Set state on A before B connects (subkeys auto-prefixed with nodeA ID)
+	mgrA.StateMap().Set("x", []byte("1")) //nolint:errcheck
+	mgrA.StateMap().Set("y", []byte("2")) //nolint:errcheck
 
 	// Now start B and connect to A
 	idB, err := identity.Load(t.TempDir())
@@ -265,12 +287,14 @@ func TestStateSyncOnConnect(t *testing.T) {
 		t.Fatal("B not connected to A")
 	}
 
-	// Poll B for both keys (should arrive via state sync)
+	// Poll B for both keys (using A's namespace prefix)
+	keyX := idA.NodeID + "/x"
+	keyY := idA.NodeID + "/y"
 	stateB := mgrB.StateMap()
 	deadline = time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
-		ex, okX := stateB.Get("x")
-		ey, okY := stateB.Get("y")
+		ex, okX := stateB.Get(keyX)
+		ey, okY := stateB.Get(keyY)
 		if okX && okY && string(ex.Value) == "1" && string(ey.Value) == "2" {
 			return // success
 		}
@@ -285,13 +309,22 @@ func TestStatePersistenceRestart(t *testing.T) {
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "test.db")
 
+	// Generate a stable identity for both runs
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pub := priv.Public().(ed25519.PublicKey)
+	hash := sha256.Sum256(pub)
+	nodeID := hex.EncodeToString(hash[:])
+
 	// First "run": create store, state map, set entries
 	st1, err := boltstore.Open(dbPath)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	m1 := state.NewMap("node-a")
+	m1 := state.NewMap(nodeID, priv)
 	if err := m1.LoadFromStore(st1); err != nil {
 		t.Fatal(err)
 	}
@@ -303,14 +336,14 @@ func TestStatePersistenceRestart(t *testing.T) {
 
 	_ = st1.Close()
 
-	// Second "run": reopen store, create new map, load
+	// Second "run": reopen store, create new map with same identity, load
 	st2, err := boltstore.Open(dbPath)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() { _ = st2.Close() }()
 
-	m2 := state.NewMap("node-a")
+	m2 := state.NewMap(nodeID, priv)
 	if err := m2.LoadFromStore(st2); err != nil {
 		t.Fatal(err)
 	}
@@ -320,12 +353,14 @@ func TestStatePersistenceRestart(t *testing.T) {
 		t.Fatalf("Len() = %d, want 2", m2.Len())
 	}
 
-	got, ok := m2.Get("color")
+	colorKey := nodeID + "/color"
+	got, ok := m2.Get(colorKey)
 	if !ok || string(got.Value) != "red" {
 		t.Fatalf("color = %q, want %q", got.Value, "red")
 	}
 
-	got, ok = m2.Get("size")
+	sizeKey := nodeID + "/size"
+	got, ok = m2.Get(sizeKey)
 	if !ok || string(got.Value) != "large" {
 		t.Fatalf("size = %q, want %q", got.Value, "large")
 	}
@@ -335,4 +370,125 @@ func TestStatePersistenceRestart(t *testing.T) {
 	if nextTs <= e2.LamportTs {
 		t.Fatalf("clock tick %d should be > max persisted ts %d", nextTs, e2.LamportTs)
 	}
+}
+
+// TestDeletePropagatesTwoNodes verifies that a /del on node A causes
+// Get on node B to return not-found after gossip propagation.
+func TestDeletePropagatesTwoNodes(t *testing.T) {
+	logging.CaptureForTest()
+
+	type testNode struct {
+		id     *identity.Identity
+		hub    *partyline.Hub
+		mgr    *transport.Manager
+		ctx    context.Context
+		cancel context.CancelFunc
+	}
+
+	makeNode := func(name string) testNode {
+		id, err := identity.Load(t.TempDir())
+		if err != nil {
+			t.Fatalf("identity %s: %v", name, err)
+		}
+		hub := partyline.NewHub(name)
+		ctx, cancel := context.WithCancel(context.Background())
+		return testNode{id: id, hub: hub, ctx: ctx, cancel: cancel}
+	}
+
+	cleanup := func(n *testNode) {
+		if n.mgr != nil {
+			n.mgr.Stop()
+		}
+		n.cancel()
+		n.hub.Stop()
+	}
+
+	nodeA := makeNode("node-a")
+	nodeB := makeNode("node-b")
+	defer func() {
+		cleanup(&nodeB)
+		cleanup(&nodeA)
+	}()
+
+	// Start B (listener)
+	cfgB := &config.Config{
+		Node: config.NodeConfig{Name: "node-b"},
+		Network: config.NetworkConfig{
+			Listen:            "127.0.0.1:0",
+			ExchangeInterval:  noDiscovery,
+			DiscoveryInterval: noDiscovery,
+		},
+	}
+	mgrB, err := transport.NewManager(cfgB, nodeB.id, nodeB.hub, nil)
+	if err != nil {
+		t.Fatalf("manager B: %v", err)
+	}
+	nodeB.mgr = mgrB
+	go nodeB.hub.Run()
+	go func() { _ = mgrB.Start(nodeB.ctx) }()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for mgrB.Addr() == "" && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// Start A (bootstraps to B)
+	cfgA := &config.Config{
+		Node: config.NodeConfig{Name: "node-a"},
+		Network: config.NetworkConfig{
+			Listen:            "127.0.0.1:0",
+			Bootstrap:         []string{mgrB.Addr()},
+			ExchangeInterval:  noDiscovery,
+			DiscoveryInterval: noDiscovery,
+		},
+	}
+	mgrA, err := transport.NewManager(cfgA, nodeA.id, nodeA.hub, nil)
+	if err != nil {
+		t.Fatalf("manager A: %v", err)
+	}
+	nodeA.mgr = mgrA
+	go nodeA.hub.Run()
+	go func() { _ = mgrA.Start(nodeA.ctx) }()
+
+	// Wait for connection
+	deadline = time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if mgrA.PeerCount() > 0 && mgrB.PeerCount() > 0 {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if mgrA.PeerCount() == 0 {
+		t.Fatal("nodes not connected")
+	}
+
+	// Set on A, wait for B to receive it
+	stateA := mgrA.StateMap()
+	stateA.Set("color", []byte("blue")) //nolint:errcheck
+
+	colorKey := nodeA.id.NodeID + "/color"
+	stateB := mgrB.StateMap()
+	deadline = time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, found := stateB.Get(colorKey); found {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if _, found := stateB.Get(colorKey); !found {
+		t.Fatal("B did not receive Set from A")
+	}
+
+	// Delete on A
+	stateA.Delete("color") //nolint:errcheck
+
+	// Poll B until it no longer has the value
+	deadline = time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, found := stateB.Get(colorKey); !found {
+			return // success
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatal("B did not receive Delete from A")
 }

--- a/internal/transport/state_sync.go
+++ b/internal/transport/state_sync.go
@@ -1,0 +1,168 @@
+package transport
+
+import (
+	"sync"
+	"time"
+
+	"micelio/internal/logging"
+	"micelio/internal/state"
+	pb "micelio/pkg/proto"
+
+	"github.com/google/uuid"
+	"google.golang.org/protobuf/proto"
+)
+
+const (
+	// stateSyncRequestCooldown is the minimum interval between StateSyncRequests
+	// from the same peer. Prevents amplification attacks where a malicious peer
+	// repeatedly requests a full state dump.
+	stateSyncRequestCooldown = 30 * time.Second
+
+	// maxStateSyncEntries is the maximum number of entries sent in a single
+	// StateSyncResponse. Prevents OOM from serializing a very large state map
+	// and keeps frame sizes bounded.
+	maxStateSyncEntries = 1000
+)
+
+var sslog = logging.For("state-sync")
+
+// sendStateSyncRequestTo sends a StateSyncRequest to a single peer.
+func (m *Manager) sendStateSyncRequestTo(p *Peer) {
+	if m.stateMap == nil {
+		return
+	}
+
+	payload, err := proto.Marshal(&pb.StateSyncRequest{})
+	if err != nil {
+		sslog.Error("marshal state_sync_request", "err", err)
+		return
+	}
+
+	env := &pb.Envelope{
+		MessageId: uuid.New().String(),
+		SenderId:  m.id.NodeID,
+		MsgType:   MsgTypeStateSyncRequest,
+		HopCount:  1,
+		Payload:   payload,
+	}
+	signEnvelope(env, m.id.PrivateKey)
+
+	envBytes, err := proto.Marshal(env)
+	if err != nil {
+		sslog.Error("marshal state_sync_request envelope", "err", err)
+		return
+	}
+
+	select {
+	case p.sendCh <- envBytes:
+		sslog.Debug("sent state_sync_request", "peer", formatNodeIDShort(p.NodeID))
+	default:
+		sslog.Warn("send buffer full, dropping state_sync_request", "peer", formatNodeIDShort(p.NodeID))
+	}
+}
+
+// sendStateSyncResponseTo sends a full state snapshot to a single peer.
+func (m *Manager) sendStateSyncResponseTo(p *Peer) {
+	if m.stateMap == nil {
+		return
+	}
+
+	snapshot := m.stateMap.Snapshot()
+	if len(snapshot) == 0 {
+		sslog.Debug("skipping empty state_sync_response", "peer", formatNodeIDShort(p.NodeID))
+		return
+	}
+
+	// Cap entries to prevent oversized responses.
+	if len(snapshot) > maxStateSyncEntries {
+		sslog.Warn("truncating state_sync_response",
+			"peer", formatNodeIDShort(p.NodeID),
+			"total", len(snapshot),
+			"sending", maxStateSyncEntries)
+		snapshot = snapshot[:maxStateSyncEntries]
+	}
+
+	pbEntries := make([]*pb.StateEntry, len(snapshot))
+	for i, e := range snapshot {
+		pbEntries[i] = &pb.StateEntry{
+			Key:       e.Key,
+			Value:     e.Value,
+			LamportTs: e.LamportTs,
+			NodeId:    e.NodeID,
+		}
+	}
+
+	payload, err := proto.Marshal(&pb.StateSyncResponse{Entries: pbEntries})
+	if err != nil {
+		sslog.Error("marshal state_sync_response", "err", err)
+		return
+	}
+
+	env := &pb.Envelope{
+		MessageId: uuid.New().String(),
+		SenderId:  m.id.NodeID,
+		MsgType:   MsgTypeStateSyncResponse,
+		HopCount:  1,
+		Payload:   payload,
+	}
+	signEnvelope(env, m.id.PrivateKey)
+
+	envBytes, err := proto.Marshal(env)
+	if err != nil {
+		sslog.Error("marshal state_sync_response envelope", "err", err)
+		return
+	}
+
+	select {
+	case p.sendCh <- envBytes:
+		sslog.Debug("sent state_sync_response", "peer", formatNodeIDShort(p.NodeID), "entries", len(snapshot))
+	default:
+		sslog.Warn("send buffer full, dropping state_sync_response", "peer", formatNodeIDShort(p.NodeID))
+	}
+}
+
+// stateSyncRequestHandler returns the callback for incoming StateSyncRequest.
+// It enforces a per-peer cooldown to prevent amplification attacks.
+func (m *Manager) stateSyncRequestHandler() func(fromPeerID string) {
+	var (
+		mu       sync.Mutex
+		lastSync = make(map[string]time.Time)
+	)
+	return func(fromPeerID string) {
+		now := time.Now()
+		mu.Lock()
+		if last, ok := lastSync[fromPeerID]; ok && now.Sub(last) < stateSyncRequestCooldown {
+			mu.Unlock()
+			sslog.Warn("rate-limited state_sync_request", "from", formatNodeIDShort(fromPeerID))
+			return
+		}
+		lastSync[fromPeerID] = now
+		mu.Unlock()
+
+		sslog.Debug("received state_sync_request", "from", formatNodeIDShort(fromPeerID))
+		m.mu.Lock()
+		p, ok := m.peers[fromPeerID]
+		m.mu.Unlock()
+		if ok {
+			go m.sendStateSyncResponseTo(p)
+		}
+	}
+}
+
+// stateSyncResponseHandler returns the callback for incoming StateSyncResponse.
+func (m *Manager) stateSyncResponseHandler() func(fromPeerID string, entries []*pb.StateEntry) {
+	return func(fromPeerID string, entries []*pb.StateEntry) {
+		sslog.Debug("received state_sync_response", "from", formatNodeIDShort(fromPeerID), "entries", len(entries))
+		for _, pbEntry := range entries {
+			entry := state.Entry{
+				Key:       pbEntry.Key,
+				Value:     pbEntry.Value,
+				LamportTs: pbEntry.LamportTs,
+				NodeID:    pbEntry.NodeId,
+			}
+			if m.stateMap.Merge(entry) {
+				m.enqueuePersist(entry)
+			}
+		}
+	}
+}

--- a/internal/transport/state_sync_internal_test.go
+++ b/internal/transport/state_sync_internal_test.go
@@ -1,0 +1,576 @@
+package transport
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/hex"
+	"log/slog"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"micelio/internal/config"
+	"micelio/internal/identity"
+	"micelio/internal/logging"
+	"micelio/internal/partyline"
+	"micelio/internal/state"
+	"micelio/internal/store"
+	boltstore "micelio/internal/store/bolt"
+	pb "micelio/pkg/proto"
+)
+
+// testManager creates a minimal Manager with real stateMap and optional store.
+func testManager(t *testing.T, st store.Store) *Manager {
+	t.Helper()
+	dir := t.TempDir()
+	id, err := identity.Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hub := partyline.NewHub("test")
+	cfg := &config.Config{
+		Node:    config.NodeConfig{Name: "test"},
+		Network: config.NetworkConfig{},
+	}
+	mgr, err := NewManager(cfg, id, hub, st)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return mgr
+}
+
+// testPeer creates a minimal Peer with a sendCh for testing.
+func testPeer(nodeID string) *Peer {
+	return &Peer{
+		NodeID: nodeID,
+		sendCh: make(chan []byte, 64),
+		done:   make(chan struct{}),
+	}
+}
+
+// removePeers removes all test peers from the manager so Stop() doesn't
+// try to close nil connections.
+func removePeers(mgr *Manager) {
+	mgr.mu.Lock()
+	mgr.peers = make(map[string]*Peer)
+	mgr.mu.Unlock()
+}
+
+// --- enqueuePersist tests ---
+
+func TestEnqueuePersist(t *testing.T) {
+	mgr := testManager(t, nil)
+	defer mgr.Stop()
+
+	entry := state.Entry{Key: "test/key", Value: []byte("val"), LamportTs: 1}
+	mgr.enqueuePersist(entry)
+
+	select {
+	case got := <-mgr.persistCh:
+		if got.Key != entry.Key {
+			t.Fatalf("got key %q, want %q", got.Key, entry.Key)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("entry not enqueued")
+	}
+}
+
+func TestEnqueuePersistBufferFull(t *testing.T) {
+	capture := logging.CaptureForTest()
+	defer capture.Restore()
+
+	mgr := testManager(t, nil)
+	defer mgr.Stop()
+
+	// Fill the buffer
+	for range cap(mgr.persistCh) {
+		mgr.persistCh <- state.Entry{Key: "fill"}
+	}
+
+	// This should be dropped with a warning
+	mgr.enqueuePersist(state.Entry{Key: "dropped"})
+
+	if capture.Count(slog.LevelWarn) == 0 {
+		t.Fatal("expected warning log for full buffer")
+	}
+}
+
+// --- persistLoop tests ---
+
+func TestPersistLoop(t *testing.T) {
+	dir := t.TempDir()
+	st, err := boltstore.Open(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = st.Close() }()
+
+	mgr := testManager(t, st)
+
+	// Start persistLoop in background
+	go mgr.persistLoop()
+
+	// Create a signed entry
+	entry, _, err := mgr.stateMap.Set("color", []byte("blue"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	mgr.enqueuePersist(entry)
+
+	// Give persistLoop time to process
+	time.Sleep(200 * time.Millisecond)
+
+	// Stop the manager to drain and exit persistLoop
+	mgr.Stop()
+
+	// Verify entry is in the store
+	got, err := st.Get([]byte("state"), []byte(entry.Key))
+	if err != nil {
+		t.Fatalf("Get from store: %v", err)
+	}
+	if got == nil {
+		t.Fatal("entry not persisted to store")
+	}
+}
+
+func TestPersistLoopDrainsOnShutdown(t *testing.T) {
+	dir := t.TempDir()
+	st, err := boltstore.Open(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = st.Close() }()
+
+	mgr := testManager(t, st)
+
+	// Enqueue entries BEFORE starting persistLoop
+	e1, _, _ := mgr.stateMap.Set("k1", []byte("v1"))
+	e2, _, _ := mgr.stateMap.Set("k2", []byte("v2"))
+	mgr.persistCh <- e1
+	mgr.persistCh <- e2
+
+	// Start persistLoop and immediately stop
+	go mgr.persistLoop()
+	time.Sleep(50 * time.Millisecond)
+	mgr.Stop()
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify both entries were drained
+	for _, key := range []string{e1.Key, e2.Key} {
+		got, err := st.Get([]byte("state"), []byte(key))
+		if err != nil {
+			t.Fatalf("Get(%q): %v", key, err)
+		}
+		if got == nil {
+			t.Fatalf("entry %q not drained on shutdown", key)
+		}
+	}
+}
+
+// --- gcLoop tests ---
+
+func TestGcLoop(t *testing.T) {
+	dir := t.TempDir()
+	st, err := boltstore.Open(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = st.Close() }()
+
+	mgr := testManager(t, st)
+	// Override GC config for fast test
+	mgr.cfg.State.TombstoneTTL = config.Duration{Duration: 0}
+	mgr.cfg.State.GCInterval = config.Duration{Duration: 50 * time.Millisecond}
+
+	// Create a tombstone and persist it
+	e, _, _ := mgr.stateMap.Set("temp", []byte("val"))
+	state.PersistEntry(st, e)
+	del, _, _ := mgr.stateMap.Delete("temp")
+	state.PersistEntry(st, del)
+
+	// Create a live entry
+	live, _, _ := mgr.stateMap.Set("live", []byte("alive"))
+	state.PersistEntry(st, live)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go mgr.gcLoop(ctx)
+
+	// Wait for GC to run at least once
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+
+	// Tombstone should be removed from state map
+	tombKey := mgr.id.NodeID + "/temp"
+	snap := mgr.stateMap.Snapshot()
+	for _, e := range snap {
+		if e.Key == tombKey {
+			t.Fatal("tombstone should have been GC'd from state map")
+		}
+	}
+
+	// Tombstone should be removed from store
+	got, err := st.Get([]byte("state"), []byte(tombKey))
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got != nil {
+		t.Fatal("tombstone should have been deleted from store")
+	}
+
+	// Live entry should still exist
+	liveKey := mgr.id.NodeID + "/live"
+	if _, ok := mgr.stateMap.Get(liveKey); !ok {
+		t.Fatal("live entry should survive GC")
+	}
+}
+
+func TestGcLoopExitsOnCancel(t *testing.T) {
+	mgr := testManager(t, nil)
+	mgr.cfg.State.TombstoneTTL = config.Duration{Duration: time.Hour}
+	mgr.cfg.State.GCInterval = config.Duration{Duration: time.Hour}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		mgr.gcLoop(ctx)
+		close(done)
+	}()
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("gcLoop did not exit on context cancel")
+	}
+}
+
+func TestGcLoopExitsOnManagerDone(t *testing.T) {
+	mgr := testManager(t, nil)
+	mgr.cfg.State.TombstoneTTL = config.Duration{Duration: time.Hour}
+	mgr.cfg.State.GCInterval = config.Duration{Duration: time.Hour}
+
+	ctx := context.Background()
+	done := make(chan struct{})
+	go func() {
+		mgr.gcLoop(ctx)
+		close(done)
+	}()
+
+	mgr.Stop()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("gcLoop did not exit on manager stop")
+	}
+}
+
+// --- sendStateSyncRequestTo tests ---
+
+func TestSendStateSyncRequestToNilStateMap(t *testing.T) {
+	mgr := testManager(t, nil)
+	defer mgr.Stop()
+
+	mgr.stateMap = nil
+	p := testPeer("remote-node")
+
+	// Should not panic
+	mgr.sendStateSyncRequestTo(p)
+
+	select {
+	case <-p.sendCh:
+		t.Fatal("should not send when stateMap is nil")
+	default:
+	}
+}
+
+func TestSendStateSyncRequestTo(t *testing.T) {
+	mgr := testManager(t, nil)
+	defer mgr.Stop()
+
+	// Set some state to create a non-empty digest
+	mgr.stateMap.Set("key1", []byte("val1")) //nolint:errcheck
+	mgr.stateMap.Set("key2", []byte("val2")) //nolint:errcheck
+
+	p := testPeer("remote-node")
+	mgr.sendStateSyncRequestTo(p)
+
+	select {
+	case data := <-p.sendCh:
+		if len(data) == 0 {
+			t.Fatal("empty envelope sent")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no message sent to peer")
+	}
+}
+
+func TestSendStateSyncRequestToBufferFull(t *testing.T) {
+	capture := logging.CaptureForTest()
+	defer capture.Restore()
+
+	mgr := testManager(t, nil)
+	defer mgr.Stop()
+
+	p := testPeer("remote-node")
+	// Fill the send buffer
+	for range cap(p.sendCh) {
+		p.sendCh <- []byte("fill")
+	}
+
+	mgr.sendStateSyncRequestTo(p)
+
+	if capture.Count(slog.LevelWarn) == 0 {
+		t.Fatal("expected warning for full send buffer")
+	}
+}
+
+// --- sendStateSyncResponseTo tests ---
+
+func TestSendStateSyncResponseToNilStateMap(t *testing.T) {
+	mgr := testManager(t, nil)
+	defer mgr.Stop()
+
+	mgr.stateMap = nil
+	p := testPeer("remote-node")
+
+	mgr.sendStateSyncResponseTo(p, nil)
+
+	select {
+	case <-p.sendCh:
+		t.Fatal("should not send when stateMap is nil")
+	default:
+	}
+}
+
+func TestSendStateSyncResponseToEmptyDelta(t *testing.T) {
+	mgr := testManager(t, nil)
+	defer mgr.Stop()
+
+	// State map is empty, so delta will be empty
+	p := testPeer("remote-node")
+	mgr.sendStateSyncResponseTo(p, nil)
+
+	select {
+	case <-p.sendCh:
+		t.Fatal("should not send empty response")
+	default:
+	}
+}
+
+func TestSendStateSyncResponseToFullDelta(t *testing.T) {
+	mgr := testManager(t, nil)
+	defer mgr.Stop()
+
+	mgr.stateMap.Set("a", []byte("1")) //nolint:errcheck
+	mgr.stateMap.Set("b", []byte("2")) //nolint:errcheck
+
+	p := testPeer("remote-node")
+	// nil known = full dump
+	mgr.sendStateSyncResponseTo(p, nil)
+
+	select {
+	case data := <-p.sendCh:
+		if len(data) == 0 {
+			t.Fatal("empty envelope sent")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no response sent")
+	}
+}
+
+func TestSendStateSyncResponseToPartialDigest(t *testing.T) {
+	mgr := testManager(t, nil)
+	defer mgr.Stop()
+
+	mgr.stateMap.Set("a", []byte("1")) //nolint:errcheck
+	mgr.stateMap.Set("b", []byte("2")) //nolint:errcheck
+
+	p := testPeer("remote-node")
+	// Peer already knows everything from this node's namespace at ts=100
+	known := map[string]uint64{mgr.id.NodeID: 100}
+	mgr.sendStateSyncResponseTo(p, known)
+
+	// Delta should be empty (peer already has everything)
+	select {
+	case <-p.sendCh:
+		t.Fatal("should not send when peer is up to date")
+	default:
+	}
+}
+
+func TestSendStateSyncResponseToBufferFull(t *testing.T) {
+	capture := logging.CaptureForTest()
+	defer capture.Restore()
+
+	mgr := testManager(t, nil)
+	defer mgr.Stop()
+
+	mgr.stateMap.Set("a", []byte("1")) //nolint:errcheck
+
+	p := testPeer("remote-node")
+	for range cap(p.sendCh) {
+		p.sendCh <- []byte("fill")
+	}
+
+	mgr.sendStateSyncResponseTo(p, nil)
+
+	if capture.Count(slog.LevelWarn) == 0 {
+		t.Fatal("expected warning for full send buffer")
+	}
+}
+
+func TestSendStateSyncResponseTruncation(t *testing.T) {
+	capture := logging.CaptureForTest()
+	defer capture.Restore()
+
+	// Create many entries from different "nodes" to exceed maxStateSyncEntries
+	_, priv, _ := ed25519.GenerateKey(nil)
+	pub := priv.Public().(ed25519.PublicKey)
+	hash := sha256.Sum256(pub)
+	nodeID := hex.EncodeToString(hash[:])
+
+	sm := state.NewMap(nodeID, priv)
+	for i := range maxStateSyncEntries + 10 {
+		sm.Set("k"+string(rune(i)), []byte("v")) //nolint:errcheck
+	}
+
+	mgr := testManager(t, nil)
+	defer mgr.Stop()
+	mgr.stateMap = sm
+
+	p := testPeer("remote-node")
+	mgr.sendStateSyncResponseTo(p, nil)
+
+	if capture.Count(slog.LevelWarn) == 0 {
+		t.Fatal("expected warning for truncated response")
+	}
+
+	select {
+	case data := <-p.sendCh:
+		if len(data) == 0 {
+			t.Fatal("empty envelope sent")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no response sent despite truncation")
+	}
+}
+
+// --- stateSyncRequestHandler tests ---
+
+func TestStateSyncRequestHandlerFirstRequest(t *testing.T) {
+	mgr := testManager(t, nil)
+	defer func() { removePeers(mgr); mgr.Stop() }()
+
+	mgr.stateMap.Set("data", []byte("val")) //nolint:errcheck
+
+	p := testPeer("peer-1")
+	mgr.mu.Lock()
+	mgr.peers["peer-1"] = p
+	mgr.mu.Unlock()
+
+	handler := mgr.stateSyncRequestHandler()
+	handler("peer-1", nil)
+
+	// Should send a response (handler spawns goroutine)
+	select {
+	case data := <-p.sendCh:
+		if len(data) == 0 {
+			t.Fatal("empty response")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("handler did not send response")
+	}
+}
+
+func TestStateSyncRequestHandlerRateLimit(t *testing.T) {
+	capture := logging.CaptureForTest()
+	defer capture.Restore()
+
+	mgr := testManager(t, nil)
+	defer func() { removePeers(mgr); mgr.Stop() }()
+
+	mgr.stateMap.Set("data", []byte("val")) //nolint:errcheck
+
+	p := testPeer("peer-1")
+	mgr.mu.Lock()
+	mgr.peers["peer-1"] = p
+	mgr.mu.Unlock()
+
+	handler := mgr.stateSyncRequestHandler()
+
+	// First request: OK
+	handler("peer-1", nil)
+	time.Sleep(100 * time.Millisecond) // let goroutine send
+
+	// Second request within cooldown: rate-limited
+	handler("peer-1", nil)
+	time.Sleep(100 * time.Millisecond)
+
+	if capture.Count(slog.LevelWarn) == 0 {
+		t.Fatal("expected rate-limit warning")
+	}
+}
+
+func TestStateSyncRequestHandlerUnknownPeer(t *testing.T) {
+	mgr := testManager(t, nil)
+	defer mgr.Stop()
+
+	handler := mgr.stateSyncRequestHandler()
+	// No peers registered — should not panic
+	handler("unknown-peer", nil)
+}
+
+// --- stateSyncResponseHandler tests ---
+
+func TestStateSyncResponseHandlerMergesEntries(t *testing.T) {
+	mgr := testManager(t, nil)
+	defer mgr.Stop()
+
+	// Create a signed entry from a remote node
+	_, remotePriv, _ := ed25519.GenerateKey(nil)
+	remotePub := remotePriv.Public().(ed25519.PublicKey)
+	remoteHash := sha256.Sum256(remotePub)
+	remoteNodeID := hex.EncodeToString(remoteHash[:])
+
+	remoteMap := state.NewMap(remoteNodeID, remotePriv)
+	entry, _, _ := remoteMap.Set("color", []byte("red"))
+
+	handler := mgr.stateSyncResponseHandler()
+	handler(remoteNodeID, stateToPBEntries(entry))
+
+	// Verify merged into local map
+	got, ok := mgr.stateMap.Get(remoteNodeID + "/color")
+	if !ok {
+		t.Fatal("entry not merged into local state map")
+	}
+	if string(got.Value) != "red" {
+		t.Fatalf("value = %q, want %q", got.Value, "red")
+	}
+}
+
+func TestStateSyncResponseHandlerEmptyEntries(t *testing.T) {
+	mgr := testManager(t, nil)
+	defer mgr.Stop()
+
+	handler := mgr.stateSyncResponseHandler()
+	// Should not panic with empty/nil entries
+	handler("peer-1", nil)
+}
+
+// stateToPBEntries converts state.Entry values to protobuf StateEntry pointers.
+func stateToPBEntries(entries ...state.Entry) []*pb.StateEntry {
+	result := make([]*pb.StateEntry, len(entries))
+	for i, e := range entries {
+		result[i] = &pb.StateEntry{
+			Key:          e.Key,
+			Value:        e.Value,
+			LamportTs:    e.LamportTs,
+			NodeId:       e.NodeID,
+			Deleted:      e.Deleted,
+			Signature:    e.Signature,
+			AuthorPubkey: e.AuthorPubkey,
+		}
+	}
+	return result
+}

--- a/pkg/proto/micelio.pb.go
+++ b/pkg/proto/micelio.pb.go
@@ -478,6 +478,202 @@ func (x *PeerExchange) GetPeers() []*PeerInfo {
 	return nil
 }
 
+// StateEntry represents a single key-value pair with LWW metadata.
+type StateEntry struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Key           string                 `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
+	Value         []byte                 `protobuf:"bytes,2,opt,name=value,proto3" json:"value,omitempty"`
+	LamportTs     uint64                 `protobuf:"varint,3,opt,name=lamport_ts,json=lamportTs,proto3" json:"lamport_ts,omitempty"` // per-entry Lamport clock
+	NodeId        string                 `protobuf:"bytes,4,opt,name=node_id,json=nodeId,proto3" json:"node_id,omitempty"`           // originator node_id (for tie-breaking)
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StateEntry) Reset() {
+	*x = StateEntry{}
+	mi := &file_proto_micelio_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StateEntry) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StateEntry) ProtoMessage() {}
+
+func (x *StateEntry) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_micelio_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StateEntry.ProtoReflect.Descriptor instead.
+func (*StateEntry) Descriptor() ([]byte, []int) {
+	return file_proto_micelio_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *StateEntry) GetKey() string {
+	if x != nil {
+		return x.Key
+	}
+	return ""
+}
+
+func (x *StateEntry) GetValue() []byte {
+	if x != nil {
+		return x.Value
+	}
+	return nil
+}
+
+func (x *StateEntry) GetLamportTs() uint64 {
+	if x != nil {
+		return x.LamportTs
+	}
+	return 0
+}
+
+func (x *StateEntry) GetNodeId() string {
+	if x != nil {
+		return x.NodeId
+	}
+	return ""
+}
+
+// StateUpdate carries a single state change (msg_type=6, gossip-relayed).
+type StateUpdate struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Entry         *StateEntry            `protobuf:"bytes,1,opt,name=entry,proto3" json:"entry,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StateUpdate) Reset() {
+	*x = StateUpdate{}
+	mi := &file_proto_micelio_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StateUpdate) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StateUpdate) ProtoMessage() {}
+
+func (x *StateUpdate) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_micelio_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StateUpdate.ProtoReflect.Descriptor instead.
+func (*StateUpdate) Descriptor() ([]byte, []int) {
+	return file_proto_micelio_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *StateUpdate) GetEntry() *StateEntry {
+	if x != nil {
+		return x.Entry
+	}
+	return nil
+}
+
+// StateSyncRequest asks a peer to send its full state (msg_type=7, direct).
+type StateSyncRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StateSyncRequest) Reset() {
+	*x = StateSyncRequest{}
+	mi := &file_proto_micelio_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StateSyncRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StateSyncRequest) ProtoMessage() {}
+
+func (x *StateSyncRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_micelio_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StateSyncRequest.ProtoReflect.Descriptor instead.
+func (*StateSyncRequest) Descriptor() ([]byte, []int) {
+	return file_proto_micelio_proto_rawDescGZIP(), []int{8}
+}
+
+// StateSyncResponse carries the full state snapshot (msg_type=8, direct).
+type StateSyncResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Entries       []*StateEntry          `protobuf:"bytes,1,rep,name=entries,proto3" json:"entries,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StateSyncResponse) Reset() {
+	*x = StateSyncResponse{}
+	mi := &file_proto_micelio_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StateSyncResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StateSyncResponse) ProtoMessage() {}
+
+func (x *StateSyncResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_micelio_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StateSyncResponse.ProtoReflect.Descriptor instead.
+func (*StateSyncResponse) Descriptor() ([]byte, []int) {
+	return file_proto_micelio_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *StateSyncResponse) GetEntries() []*StateEntry {
+	if x != nil {
+		return x.Entries
+	}
+	return nil
+}
+
 var File_proto_micelio_proto protoreflect.FileDescriptor
 
 const file_proto_micelio_proto_rawDesc = "" +
@@ -521,7 +717,19 @@ const file_proto_micelio_proto_rawDesc = "" +
 	"\x0eed25519_pubkey\x18\x04 \x01(\fR\red25519Pubkey\x12\x1b\n" +
 	"\tlast_seen\x18\x05 \x01(\x04R\blastSeen\"7\n" +
 	"\fPeerExchange\x12'\n" +
-	"\x05peers\x18\x01 \x03(\v2\x11.micelio.PeerInfoR\x05peersB\x13Z\x11micelio/pkg/protob\x06proto3"
+	"\x05peers\x18\x01 \x03(\v2\x11.micelio.PeerInfoR\x05peers\"l\n" +
+	"\n" +
+	"StateEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\fR\x05value\x12\x1d\n" +
+	"\n" +
+	"lamport_ts\x18\x03 \x01(\x04R\tlamportTs\x12\x17\n" +
+	"\anode_id\x18\x04 \x01(\tR\x06nodeId\"8\n" +
+	"\vStateUpdate\x12)\n" +
+	"\x05entry\x18\x01 \x01(\v2\x13.micelio.StateEntryR\x05entry\"\x12\n" +
+	"\x10StateSyncRequest\"B\n" +
+	"\x11StateSyncResponse\x12-\n" +
+	"\aentries\x18\x01 \x03(\v2\x13.micelio.StateEntryR\aentriesB\x13Z\x11micelio/pkg/protob\x06proto3"
 
 var (
 	file_proto_micelio_proto_rawDescOnce sync.Once
@@ -535,22 +743,28 @@ func file_proto_micelio_proto_rawDescGZIP() []byte {
 	return file_proto_micelio_proto_rawDescData
 }
 
-var file_proto_micelio_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
+var file_proto_micelio_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
 var file_proto_micelio_proto_goTypes = []any{
-	(*Envelope)(nil),     // 0: micelio.Envelope
-	(*PeerHello)(nil),    // 1: micelio.PeerHello
-	(*PeerHelloAck)(nil), // 2: micelio.PeerHelloAck
-	(*ChatMessage)(nil),  // 3: micelio.ChatMessage
-	(*PeerInfo)(nil),     // 4: micelio.PeerInfo
-	(*PeerExchange)(nil), // 5: micelio.PeerExchange
+	(*Envelope)(nil),          // 0: micelio.Envelope
+	(*PeerHello)(nil),         // 1: micelio.PeerHello
+	(*PeerHelloAck)(nil),      // 2: micelio.PeerHelloAck
+	(*ChatMessage)(nil),       // 3: micelio.ChatMessage
+	(*PeerInfo)(nil),          // 4: micelio.PeerInfo
+	(*PeerExchange)(nil),      // 5: micelio.PeerExchange
+	(*StateEntry)(nil),        // 6: micelio.StateEntry
+	(*StateUpdate)(nil),       // 7: micelio.StateUpdate
+	(*StateSyncRequest)(nil),  // 8: micelio.StateSyncRequest
+	(*StateSyncResponse)(nil), // 9: micelio.StateSyncResponse
 }
 var file_proto_micelio_proto_depIdxs = []int32{
 	4, // 0: micelio.PeerExchange.peers:type_name -> micelio.PeerInfo
-	1, // [1:1] is the sub-list for method output_type
-	1, // [1:1] is the sub-list for method input_type
-	1, // [1:1] is the sub-list for extension type_name
-	1, // [1:1] is the sub-list for extension extendee
-	0, // [0:1] is the sub-list for field type_name
+	6, // 1: micelio.StateUpdate.entry:type_name -> micelio.StateEntry
+	6, // 2: micelio.StateSyncResponse.entries:type_name -> micelio.StateEntry
+	3, // [3:3] is the sub-list for method output_type
+	3, // [3:3] is the sub-list for method input_type
+	3, // [3:3] is the sub-list for extension type_name
+	3, // [3:3] is the sub-list for extension extendee
+	0, // [0:3] is the sub-list for field type_name
 }
 
 func init() { file_proto_micelio_proto_init() }
@@ -564,7 +778,7 @@ func file_proto_micelio_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_proto_micelio_proto_rawDesc), len(file_proto_micelio_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   6,
+			NumMessages:   10,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/proto/micelio.proto
+++ b/proto/micelio.proto
@@ -58,3 +58,24 @@ message PeerInfo {
 message PeerExchange {
     repeated PeerInfo peers = 1;
 }
+
+// StateEntry represents a single key-value pair with LWW metadata.
+message StateEntry {
+    string key        = 1;
+    bytes  value      = 2;
+    uint64 lamport_ts = 3;  // per-entry Lamport clock
+    string node_id    = 4;  // originator node_id (for tie-breaking)
+}
+
+// StateUpdate carries a single state change (msg_type=6, gossip-relayed).
+message StateUpdate {
+    StateEntry entry = 1;
+}
+
+// StateSyncRequest asks a peer to send its full state (msg_type=7, direct).
+message StateSyncRequest {}
+
+// StateSyncResponse carries the full state snapshot (msg_type=8, direct).
+message StateSyncResponse {
+    repeated StateEntry entries = 1;
+}

--- a/proto/micelio.proto
+++ b/proto/micelio.proto
@@ -60,11 +60,16 @@ message PeerExchange {
 }
 
 // StateEntry represents a single key-value pair with LWW metadata.
+// Each entry is self-authenticating: it carries the author's ED25519 public key
+// and a signature over all semantic fields. Nodes verify before accepting.
 message StateEntry {
-    string key        = 1;
-    bytes  value      = 2;
-    uint64 lamport_ts = 3;  // per-entry Lamport clock
-    string node_id    = 4;  // originator node_id (for tie-breaking)
+    string key           = 1;
+    bytes  value         = 2;
+    uint64 lamport_ts    = 3;  // per-entry Lamport clock
+    string node_id       = 4;  // originator node_id = sha256(author_pubkey)
+    bool   deleted       = 5;  // tombstone marker for soft-delete
+    bytes  signature     = 6;  // ED25519 signature over (key, value, lamport_ts, node_id, deleted)
+    bytes  author_pubkey = 7;  // raw 32-byte ED25519 public key of author
 }
 
 // StateUpdate carries a single state change (msg_type=6, gossip-relayed).
@@ -72,10 +77,15 @@ message StateUpdate {
     StateEntry entry = 1;
 }
 
-// StateSyncRequest asks a peer to send its full state (msg_type=7, direct).
-message StateSyncRequest {}
+// StateSyncRequest asks a peer for state entries it is missing (msg_type=7, direct).
+// The known map is a version vector: for each nodeID, the highest lamport_ts
+// the requester already has. The responder sends only entries newer than this.
+// An empty map means "send everything" (fresh node).
+message StateSyncRequest {
+    map<string, uint64> known = 1;
+}
 
-// StateSyncResponse carries the full state snapshot (msg_type=8, direct).
+// StateSyncResponse carries the delta state entries (msg_type=8, direct).
 message StateSyncResponse {
     repeated StateEntry entries = 1;
 }


### PR DESCRIPTION
## Summary

Distributed key-value state map for the P2P mesh, where **each node owns its namespace** and entries are **cryptographically self-authenticating**. State propagates in real-time via gossip and new peers receive only the delta they're missing via **version vector digest sync**.

## Features

### Distributed LWW State Map
- Last-Writer-Wins conflict resolution with **Lamport logical clocks**
- Tie-breaking: higher `lamport_ts` wins; on tie, lexicographically greater `node_id` wins
- Persistence to bbolt with write-behind worker for backpressure control

### Per-Entry Cryptographic Signatures
- Each `StateEntry` carries the author's ED25519 public key and a signature over all semantic fields (`key`, `value`, `lamport_ts`, `node_id`, `deleted`)
- Nodes verify signature before accepting any remote entry — invalid entries are rejected
- Model inspired by Bitcoin's redeem script: the entry itself proves its authenticity

### Namespace Authorization
- Keys are namespaced: `<nodeID>/<subkey>` where `nodeID = sha256(ed25519_pubkey)`
- Only the owner of a key's namespace can write to it
- Verification: `sha256(author_pubkey) == nodeID` prefix of the key
- Prevents unauthorized writes even if signature is valid (a node can't write to another node's namespace)

### Tombstone GC
- Soft-delete via tombstone markers (`deleted = true`)
- Configurable `tombstone_ttl` (default 24h) — tombstones are reaped after TTL
- GC runs periodically, cleaning both in-memory map and bbolt store

### Delta State Sync (Version Vector Digest)
- On connect, peers exchange a **compact digest** `map[nodeID]uint64` summarizing their state (max `lamport_ts` per node)
- Responder sends only entries where `entry.LamportTs > known[entry.NodeID]` — the **delta**
- Backward compatible: empty digest = fresh node → receives full state
- Benchmarked with 1000-node simulation: 99% bandwidth saving when peer is 1% stale

### SSH Partyline Commands
- `/set <key> <value>` — create/update an entry in the local namespace
- `/get <key>` — retrieve an entry (full key: `<nodeID>/<subkey>`)
- `/del <key>` — soft-delete (tombstone) an entry
- `/state` — list all entries including tombstones

## Architecture

| Component | Description |
|-----------|-------------|
| `internal/state/map.go` | LWW Map with Lamport clock, `Digest()`, `SnapshotDelta()` |
| `internal/state/auth.go` | `SignEntry()`, `VerifyEntry()` — per-entry ED25519 signatures + namespace check |
| `internal/state/persistence.go` | bbolt persistence with tombstone GC |
| `internal/transport/state_sync.go` | Delta sync protocol: digest request → delta response |
| `internal/transport/peer.go` | StateSyncRequest deserialization, callback dispatch |
| `proto/micelio.proto` | `StateEntry`, `StateUpdate`, `StateSyncRequest{known}`, `StateSyncResponse` |

## Security Hardening

| Protection | Detail |
|------------|--------|
| Per-entry signatures | ED25519 signature over `(key, value, lamport_ts, node_id, deleted)` |
| Namespace ownership | `sha256(author_pubkey)` must match key prefix — can't write to others' namespace |
| Key/value limits | Max key 256B, max value 4KB |
| Entry count cap | Max 10K entries in state map |
| Clock poisoning | Reject `lamport_ts > 1<<62` before calling `Witness()` |
| Amplification attack | StateSyncRequest rate-limited to 1 per 30s per peer |
| Response size | StateSyncResponse capped at 1000 entries |
| Persist backpressure | Bounded channel (256) + single worker |

## Benchmark Results (1000 nodes, 100 updates each)

```
BenchmarkDigest1000Nodes            ~40µs/op
BenchmarkSnapshot1000Nodes          ~350µs/op
BenchmarkSnapshotDeltaFullyCaughtUp ~40µs/op     0 allocs
BenchmarkSnapshotDelta1PercentStale ~45µs/op     10 entries (vs 1000)
BenchmarkSnapshotDelta50PercentStale ~200µs/op   500 entries
```

Delta sync savings: a peer that is 99% caught up receives **only 1% of entries** instead of a full snapshot.

## Test Plan

- [x] `internal/state/` — 40+ unit tests (lamport clock, LWW map, signatures, namespace auth, persistence, GC, digest, delta)
- [x] `internal/transport/` — integration tests (two-node sync, conflict resolution, sync on connect, delta sync, persistence restart, tombstone propagation)
- [x] Benchmarks: 1000-node delta sync simulation
- [x] Full test suite passes (`go test ./...`)
- [ ] Manual test: start 2+ nodes, `/set` on one, `/get` on the other
- [ ] Manual test: restart a node, verify state restored from bbolt
- [ ] Manual test: `/del` on one node, verify tombstone propagates